### PR TITLE
chore: remove coinbase connector

### DIFF
--- a/dapps/W3MWagmi/ios/Podfile.lock
+++ b/dapps/W3MWagmi/ios/Podfile.lock
@@ -1279,27 +1279,6 @@ PODS:
     - React-Core
   - react-native-get-random-values (1.11.0):
     - React-Core
-  - react-native-mmkv (3.2.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-safe-area-context (5.3.0):
@@ -2048,7 +2027,6 @@ DEPENDENCIES:
   - "react-native-compat (from `../node_modules/@walletconnect/react-native-compat`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
-  - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -2194,8 +2172,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-config"
   react-native-get-random-values:
     :path: "../node_modules/react-native-get-random-values"
-  react-native-mmkv:
-    :path: "../node_modules/react-native-mmkv"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -2330,7 +2306,6 @@ SPEC CHECKSUMS:
   react-native-compat: ec445424751aefe5cde3ab9a819f49e7122641e4
   react-native-config: 3367df9c1f25bb96197007ec531c7087ed4554c3
   react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-mmkv: 55e8a074ae9cb919609755d7271c16b242c2603f
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-safe-area-context: 286b3e7b5589795bb85ffc38faf4c0706c48a092
   react-native-webview: f174d18dec20376e312bd4e6e76cb21b9abf0ac9

--- a/dapps/W3MWagmi/package.json
+++ b/dapps/W3MWagmi/package.json
@@ -37,7 +37,6 @@
     "react-native-device-info": "14.0.4",
     "react-native-gesture-handler": "2.24.0",
     "react-native-get-random-values": "1.11.0",
-    "react-native-mmkv": "3.2.0",
     "react-native-modal": "14.0.0-rc.0",
     "react-native-reanimated": "3.17.1",
     "react-native-safe-area-context": "5.3.0",

--- a/dapps/W3MWagmi/src/App.tsx
+++ b/dapps/W3MWagmi/src/App.tsx
@@ -9,7 +9,7 @@ import {
 } from '@reown/appkit-wagmi-react-native';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 
-import {coinbaseConnector} from '@reown/appkit-coinbase-wagmi-react-native';
+// import {coinbaseConnector} from '@reown/appkit-coinbase-wagmi-react-native';
 import {authConnector} from '@reown/appkit-auth-wagmi-react-native';
 import {WagmiProvider} from 'wagmi';
 import {handleResponse} from '@coinbase/wallet-mobile-sdk';
@@ -51,9 +51,10 @@ const clipboardClient = {
   },
 };
 
-const _coinbaseConnector = coinbaseConnector({
-  redirect: metadata?.redirect?.universal || '',
-});
+// Removed coinbase connector for now, as it's not compatible with React Native New Architecture
+// const _coinbaseConnector = coinbaseConnector({
+//   redirect: metadata?.redirect?.universal || '',
+// });
 
 const _authConnector = authConnector({
   projectId,
@@ -64,7 +65,9 @@ const wagmiConfig = defaultWagmiConfig({
   chains,
   projectId,
   metadata,
-  extraConnectors: [_coinbaseConnector, _authConnector],
+  extraConnectors: [
+    // _coinbaseConnector,
+    _authConnector],
 });
 
 const customWallets = getCustomWallets();

--- a/dapps/W3MWagmi/yarn.lock
+++ b/dapps/W3MWagmi/yarn.lock
@@ -7112,7 +7112,6 @@ __metadata:
     react-native-device-info: 14.0.4
     react-native-gesture-handler: 2.24.0
     react-native-get-random-values: 1.11.0
-    react-native-mmkv: 3.2.0
     react-native-modal: 14.0.0-rc.0
     react-native-reanimated: 3.17.1
     react-native-safe-area-context: 5.3.0
@@ -14664,16 +14663,6 @@ __metadata:
     react: ">=18.2.0"
     react-native: ">=0.73.0"
   checksum: 4e07c1e34c01c8d50fd7c1d0460db06f6f0515197405230386a8ffb950cb724b10743af032310d1384df0a90059bfb8992ba2d93344ce86315315f0493feccc2
-  languageName: node
-  linkType: hard
-
-"react-native-mmkv@npm:3.2.0":
-  version: 3.2.0
-  resolution: "react-native-mmkv@npm:3.2.0"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 766944a7cbf265e27b57576e51bff8604cd8f58c88eaec78bd93d4ce10ff9127d5f75f4c3bb03d6c7ce5dafa07c65e233d5363c0504db802cc88eaf1ccbffaa1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
Remove Coinbase connector from wagmi sample as its not compatible with React Native new architecture