### PR TITLE
fix(pos-app): explain below-minimum amount failures

### DIFF
--- a/dapps/pos-app/app/_layout.tsx
+++ b/dapps/pos-app/app/_layout.tsx
@@ -212,8 +212,15 @@ export default Sentry.wrap(function RootLayout() {
                   headerTitleAlign: "center",
                   headerStyle: {
                     backgroundColor: Theme[headerBackgroundColor],
+                  },
+                  headerRightContainerStyle: {
                     ...(Platform.OS === "web" && {
-                      paddingHorizontal: Spacing["spacing-3"],
+                      paddingRight: Spacing["spacing-3"],
+                    }),
+                  },
+                  headerLeftContainerStyle: {
+                    ...(Platform.OS === "web" && {
+                      paddingLeft: Spacing["spacing-3"],
                     }),
                   },
                   contentStyle: {

--- a/dapps/pos-app/app/payment-failure.tsx
+++ b/dapps/pos-app/app/payment-failure.tsx
@@ -12,6 +12,10 @@ import { useSettingsStore } from "@/store/useSettingsStore";
 import { getPaymentErrorMessage } from "@/utils/payment-errors";
 import { useAssets } from "expo-asset";
 
+// The params can't be declared optional here: `UnknownOutputParams` indexes to
+// `string | string[]`, so `?` widens to undefined and breaks the constraint.
+// Read them through `Partial` below instead, since `scan.tsx` only passes
+// `errorCode`/`minAmount` when it has them.
 interface ScreenParams extends UnknownOutputParams {
   amount: string;
   errorCode: string; // Error status from API (e.g., "expired") or error code (e.g., "invalid_api_key")
@@ -21,7 +25,7 @@ interface ScreenParams extends UnknownOutputParams {
 export default function PaymentFailureScreen() {
   const Theme = useTheme();
   const { top } = useSafeAreaInsets();
-  const params = useLocalSearchParams<ScreenParams>();
+  const params: Partial<ScreenParams> = useLocalSearchParams<ScreenParams>();
   const currencyCode = useSettingsStore((state) => state.currency);
   const [assets] = useAssets([require("@/assets/images/warning_circle.png")]);
 

--- a/dapps/pos-app/app/payment-failure.tsx
+++ b/dapps/pos-app/app/payment-failure.tsx
@@ -8,21 +8,27 @@ import { Button } from "@/components/button";
 import { ThemedText } from "@/components/themed-text";
 import { BorderRadius, Spacing } from "@/constants/spacing";
 import { useTheme } from "@/hooks/use-theme-color";
+import { useSettingsStore } from "@/store/useSettingsStore";
 import { getPaymentErrorMessage } from "@/utils/payment-errors";
 import { useAssets } from "expo-asset";
 
 interface ScreenParams extends UnknownOutputParams {
   amount: string;
   errorCode: string; // Error status from API (e.g., "expired") or error code (e.g., "invalid_api_key")
+  minAmount: string; // Minimum amount in cents, only set for "amount_too_low"
 }
 
 export default function PaymentFailureScreen() {
   const Theme = useTheme();
   const { top } = useSafeAreaInsets();
   const params = useLocalSearchParams<ScreenParams>();
+  const currencyCode = useSettingsStore((state) => state.currency);
   const [assets] = useAssets([require("@/assets/images/warning_circle.png")]);
 
-  const { title, subtitle } = getPaymentErrorMessage(params.errorCode);
+  const { title, subtitle } = getPaymentErrorMessage(params.errorCode, {
+    minAmountCents: params.minAmount,
+    currencyCode,
+  });
 
   const handleRetry = () => {
     router.dismissTo("/amount");

--- a/dapps/pos-app/app/scan.tsx
+++ b/dapps/pos-app/app/scan.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/utils/currency";
 import { formatCountdown } from "@/utils/misc";
 import { resetNavigation } from "@/utils/navigation";
+import { AMOUNT_TOO_LOW, parseMinAmountCents } from "@/utils/payment-errors";
 import { showErrorToast, showSuccessToast } from "@/utils/toast";
 import { useAssets } from "expo-asset";
 import * as Clipboard from "expo-clipboard";
@@ -85,7 +86,7 @@ export default function ScanScreen() {
   }, [paymentId, amount]);
 
   const onFailure = useCallback(
-    (errorCode?: string) => {
+    (errorCode?: string, minAmount?: string) => {
       if (hasNavigatedRef.current) return;
       hasNavigatedRef.current = true;
       router.dismiss();
@@ -94,6 +95,7 @@ export default function ScanScreen() {
         params: {
           amount,
           ...(errorCode && { errorCode }),
+          ...(minAmount && { minAmount }),
         },
       });
     },
@@ -164,7 +166,14 @@ export default function ScanScreen() {
           "initiatePayment",
           { error },
         );
-        onFailure(error.code);
+        // The below-minimum rejection only carries the floor in its message, so
+        // parse it here and keep the raw server string out of the route params.
+        const minAmountCents = parseMinAmountCents(error.message);
+        if (minAmountCents) {
+          onFailure(AMOUNT_TOO_LOW, minAmountCents);
+        } else {
+          onFailure(error.code);
+        }
       }
     }
 

--- a/dapps/pos-app/e2e/README.md
+++ b/dapps/pos-app/e2e/README.md
@@ -21,12 +21,15 @@ serve them.
 ## Prerequisites
 
 1. Install Maestro CLI:
+
    ```bash
    curl -Ls "https://get.maestro.mobile.dev" | bash
    ```
+
    You also need Google Chrome / Chromium installed.
 
 2. Build and serve the web app (from `dapps/pos-app`):
+
    ```bash
    npm run web:build
    # canvaskit.wasm is emitted at dist/ root, but the bundle requests it from the
@@ -35,15 +38,16 @@ serve them.
    cp dist/canvaskit.wasm dist/_expo/static/js/web/canvaskit.wasm
    npx serve -s dist -l 8081
    ```
+
    To run the **payment** flows locally you need the `/api` proxy too — use
    `npx vercel dev --listen 8081` instead of `serve` (serves the static build
-   *and* the serverless functions; requires Vercel login + the pay-API env).
+   _and_ the serverless functions; requires Vercel login + the pay-API env).
 
 3. Configure a merchant so payment flows can reach the amount/scan screens. The
    amount-based flows need `EXPO_PUBLIC_DEFAULT_MERCHANT_ID` and
    `EXPO_PUBLIC_DEFAULT_CUSTOMER_API_KEY` in `.env` **at build time** (they are
    seeded into the settings store on first load; without them "Start payment"
-   redirects to Settings). `payment-flow.yaml` additionally needs *valid* creds +
+   redirects to Settings). `payment-flow.yaml` additionally needs _valid_ creds +
    network to mint a real gateway QR — in CI these are baked into the tested
    deployment from the Vercel `pos-demo` project's environment variables at
    build time (configured in the Vercel dashboard, not in this repo).
@@ -68,12 +72,12 @@ Add `--headless` to run without a visible browser window (as CI does under xvfb)
 
 ## Test Files
 
-| File | Tags | Description |
-|------|------|-------------|
-| `payment-flow.yaml` | `payment` | Start payment → enter $0.01 → charge → wait for QR → tap QR copies the payment link. Needs valid merchant creds + network. |
-| `payment-cancel.yaml` | `payment` | Same prelude as `payment-flow`, then cancel returns to a fresh amount screen (and cancels the payment at the gateway). |
-| `invalid-amount.yaml` | `amount` | Charge button stays "Enter amount"/disabled at empty/`0`; enables once a non-zero amount is entered. |
-| `keypad.yaml` | `amount` | Keypad decimal handling (single decimal, max 2 fractional digits) and backspace. |
+| File                  | Tags      | Description                                                                                                                |
+| --------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `payment-flow.yaml`   | `payment` | Start payment → enter $0.01 → charge → wait for QR → tap QR copies the payment link. Needs valid merchant creds + network. |
+| `payment-cancel.yaml` | `payment` | Same prelude as `payment-flow`, then cancel returns to a fresh amount screen (and cancels the payment at the gateway).     |
+| `invalid-amount.yaml` | `amount`  | Charge button stays "Enter amount"/disabled at empty/`0`; enables once a non-zero amount is entered.                       |
+| `keypad.yaml`         | `amount`  | Keypad decimal handling (single decimal, max 2 fractional digits) and backspace.                                           |
 
 Shared steps live in `common/*.yaml` (the `$0.01`→QR prelude, run via `runFlow`).
 Flows there are **not** picked up as standalone tests — neither by CI's

--- a/dapps/pos-app/utils/payment-errors.test.ts
+++ b/dapps/pos-app/utils/payment-errors.test.ts
@@ -1,6 +1,70 @@
-import { getPaymentErrorMessage } from "./payment-errors";
+import {
+  AMOUNT_TOO_LOW,
+  getPaymentErrorMessage,
+  parseMinAmountCents,
+} from "./payment-errors";
+
+describe("parseMinAmountCents", () => {
+  it("extracts the minimum in cents from the API validation message", () => {
+    expect(
+      parseMinAmountCents(
+        "Validation error: Amount must be at least 14 to cover fees",
+      ),
+    ).toBe("14");
+  });
+
+  it("returns undefined for other validation messages", () => {
+    expect(
+      parseMinAmountCents("Validation error: referenceId is required"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when message is undefined", () => {
+    expect(parseMinAmountCents(undefined)).toBeUndefined();
+  });
+});
 
 describe("getPaymentErrorMessage", () => {
+  describe("amount below minimum", () => {
+    it("formats the minimum in USD", () => {
+      const result = getPaymentErrorMessage(AMOUNT_TOO_LOW, {
+        minAmountCents: "14",
+        currencyCode: "USD",
+      });
+      expect(result.title).toBe("Amount is too low");
+      expect(result.subtitle).toContain("$0.14");
+    });
+
+    it("formats the minimum in EUR with the symbol on the right", () => {
+      const result = getPaymentErrorMessage(AMOUNT_TOO_LOW, {
+        minAmountCents: "14",
+        currencyCode: "EUR",
+      });
+      expect(result.subtitle).toContain("0.14€");
+    });
+
+    it("uses the minimum reported by the API rather than a hardcoded one", () => {
+      const result = getPaymentErrorMessage(AMOUNT_TOO_LOW, {
+        minAmountCents: "250",
+        currencyCode: "USD",
+      });
+      expect(result.subtitle).toContain("$2.50");
+    });
+
+    it("defaults to USD when no currency is provided", () => {
+      const result = getPaymentErrorMessage(AMOUNT_TOO_LOW, {
+        minAmountCents: "14",
+      });
+      expect(result.subtitle).toContain("$0.14");
+    });
+
+    it("returns default message when the minimum is missing", () => {
+      const result = getPaymentErrorMessage(AMOUNT_TOO_LOW);
+      expect(result.title).toBe("This payment didn't go through");
+      expect(result.subtitle).toContain("No funds were moved");
+    });
+  });
+
   describe("known error statuses", () => {
     it('returns expired title and subtitle for "expired" status', () => {
       const result = getPaymentErrorMessage("expired");
@@ -18,6 +82,13 @@ describe("getPaymentErrorMessage", () => {
       const result = getPaymentErrorMessage("cancelled");
       expect(result.title).toBe("Payment cancelled");
       expect(result.subtitle).toContain("No funds were moved");
+    });
+
+    it('returns validation message for "params_validation" status', () => {
+      const result = getPaymentErrorMessage("params_validation");
+      expect(result.title).toBe("This payment didn't go through");
+      expect(result.subtitle).toContain("Something's off with this payment");
+      expect(result.subtitle).not.toContain("connection");
     });
   });
 

--- a/dapps/pos-app/utils/payment-errors.ts
+++ b/dapps/pos-app/utils/payment-errors.ts
@@ -1,3 +1,5 @@
+import { formatFiatAmount } from "./currency";
+
 interface PaymentErrorMessage {
   title: string;
   subtitle: string;
@@ -23,16 +25,54 @@ const ERROR_MESSAGES: Record<string, PaymentErrorMessage> = {
     subtitle:
       "Your API key is invalid. No funds were moved. Check your credentials in Settings and try again.",
   },
+  params_validation: {
+    title: "This payment didn't go through",
+    subtitle:
+      "No funds were moved. Something's off with this payment's details. Check your settings and start a new payment.",
+  },
 };
+
+/** Synthetic code: the API reports this as a generic `params_validation`. */
+export const AMOUNT_TOO_LOW = "amount_too_low";
+
+// "Validation error: Amount must be at least 14 to cover fees" (14 = cents)
+const MIN_AMOUNT_PATTERN = /amount must be at least\s+(\d+)/i;
+
+/**
+ * Extract the minimum amount in cents from an API error message
+ * @param message - The error message from the API
+ * @returns The minimum amount in cents, or undefined if not a below-minimum rejection
+ */
+export function parseMinAmountCents(message?: string): string | undefined {
+  return message?.match(MIN_AMOUNT_PATTERN)?.[1];
+}
+
+interface PaymentErrorContext {
+  minAmountCents?: string;
+  currencyCode?: string;
+}
 
 /**
  * Converts payment error statuses to user-friendly title and subtitle
  * @param errorStatus - The error status from the API (e.g., "expired")
+ * @param context - Extra values needed to build dynamic copy
  * @returns Object with title and subtitle for the error screen
  */
 export function getPaymentErrorMessage(
   errorStatus?: string,
+  context?: PaymentErrorContext,
 ): PaymentErrorMessage {
+  if (errorStatus === AMOUNT_TOO_LOW && context?.minAmountCents) {
+    const minAmount = formatFiatAmount(
+      context.minAmountCents,
+      context.currencyCode,
+    );
+    return {
+      title: "Amount is too low",
+      subtitle: `Payments must be at least ${minAmount} to cover network fees. Start a new payment with a higher amount.`,
+    };
+  }
+
   if (!errorStatus) {
     return DEFAULT_ERROR;
   }


### PR DESCRIPTION
## Problem

Charging a very small amount fails at payment creation with a generic validation error:

```json
{ "code": "params_validation", "message": "Validation error: Amount must be at least 14 to cover fees" }
```

`params_validation` isn't in the failure-copy map and `scan.tsx` only forwarded `error.code`, so the merchant got the catch-all *"This payment didn't go through / No funds were moved. Start a new payment, or check your connection and try again."* Nothing pointed at the amount, and retrying the same amount always failed.

## Change

- `utils/payment-errors.ts`: new `parseMinAmountCents()` pulls the floor out of the API message, and `getPaymentErrorMessage()` takes an optional context to build the copy — *"Amount is too low / Payments must be at least $0.14 to cover network fees. Start a new payment with a higher amount."* The minimum comes from the API (not a hardcoded constant) and renders through the existing `formatFiatAmount`, so EUR shows `0.14€`.
- `app/scan.tsx`: on a below-minimum rejection, forwards `errorCode=amount_too_low&minAmount=14`. Only the parsed cents cross the route boundary — the raw server string stays in the log store, so it never lands in the web URL.
- Remaining `params_validation` errors now map to copy that points at the payment's details instead of blaming the network.

Detection is keyed on the message, not on `code === "params_validation"`, because that code is a generic bucket for any bad param — it must not own amount-specific copy.

## Screenshot
<img height="700" alt="Screenshot 2026-08-07 at 11 10 11 AM" src="https://github.com/user-attachments/assets/1e0a2ab5-a88d-4240-8c51-0f90b2a93110" />


## Testing

- `npx jest` — 234 passed (12 suites), including 9 new cases covering the parser, USD/EUR formatting, a non-14 minimum, and the fallbacks.
- Drove the web build with Maestro against the real failure route for `amount_too_low` (asserting `$0.14`), `params_validation`, `expired`, and `cancelled` — new copy renders and the existing statuses are unaffected. Negative control confirmed the assertions can fail.
- `npx expo lint` + `prettier --check` clean; `tsc --noEmit` adds no new errors (the pre-existing `app/_layout.tsx` `headerTitle` error remains).

## Note

`e2e/common/create-payment-qr.yaml` charges **$0.01**, which is below this 14¢ floor. The last CI runs (Jul 21) passed, so the floor looks newer than those runs — if it applies to the `pos-demo` merchant, `payment-flow.yaml` and `payment-cancel.yaml` will now hit exactly this error and need a higher amount. Left alone here since it's out of scope for this fix.