### PR TITLE
chore: skip Vercel preview builds for unaffected apps

### DIFF
--- a/dapps/appkit-wagmi/vercel.json
+++ b/dapps/appkit-wagmi/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ."
+}

--- a/dapps/pos-app/vercel.json
+++ b/dapps/pos-app/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD .",
   "cleanUrls": true,
   "outputDirectory": "dist",
   "rewrites": [

--- a/wallets/rn_cli_wallet/vercel.json
+++ b/wallets/rn_cli_wallet/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ."
+}


### PR DESCRIPTION
## Problem

Each app is a **separate Vercel project** watching the same repo, so every push/PR deploys previews of **all** of them — e.g. a POS-only change also rebuilds appkit and walletkit previews. This isn't a Turborepo, so there's no affected-graph; each project needs its own gate.

## Fix

Add an **Ignored Build Step** via `vercel.json` `ignoreCommand` to the deployed web projects. Since each project's Vercel **Root Directory** is its own app folder, the command runs from there:

```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD ."
```

Vercel semantics: exit `0` (no changes in the folder) → **skip build**, exit `1` (changes) → build. So each project only builds when files in its own directory change.

Scoped to the three deployed web projects:
- `dapps/pos-app`
- `dapps/appkit-wagmi`
- `wallets/rn_cli_wallet`

## Note / limitation

`HEAD^ HEAD` diffs only the tip commit vs its parent — the Vercel-documented default, fine for typical per-commit preview updates. A multi-commit push where the app changed only in an *earlier* commit could be skipped. If we want to be robust against that, switch to diffing the base branch:
```
git fetch origin main --depth=1 && git diff --quiet origin/main HEAD .
```

Requires each project's Vercel Root Directory to be set to the app folder (confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)