### PR TITLE
chore(pos-app): correct iOS permission strings and add AAB build script

### DIFF
--- a/dapps/pos-app/AGENTS.md
+++ b/dapps/pos-app/AGENTS.md
@@ -316,6 +316,7 @@ This project uses **npm** (not pnpm or yarn). Always use `npm` commands for inst
 - `npm run ios`: Run on iOS
 - `npm run web`: Run on web
 - `npm run android:build`: Build Android release APK
+- `npm run android:build:aab`: Build Android App Bundle (AAB) for release. Output: `android/app/build/outputs/bundle/release/app-release.aab`
 - `npm run lint`: Run ESLint
 - `npm test`: Run Jest tests
 
@@ -589,6 +590,14 @@ export const Variants: Record<VariantName, Variant> = {
    ```
 
    Output: `android/app/build/outputs/apk/release/app-release.apk`
+
+   For an **Android App Bundle (AAB)** instead (required for Play Store uploads):
+
+   ```bash
+   npm run android:build:aab
+   ```
+
+   Output: `android/app/build/outputs/bundle/release/app-release.aab`
 
 3. **Install via USB**:
    ```bash

--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -36,7 +36,7 @@
         "android.permission.BLUETOOTH_ADVERTISE",
         "android.permission.USB_PERMISSION"
       ],
-      "versionCode": 28
+      "versionCode": 29
     },
     "web": {
       "output": "static",

--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -15,9 +15,8 @@
         "usesNonExemptEncryption": false
       },
       "infoPlist": {
-        "NFCReaderUsageDescription": "This app requires NFC to send messages",
-        "NSLocationWhenInUseUsageDescription": "This app requires location when using the camera",
-        "NSBluetoothAlwaysUsageDescription": "This app requires Bluetooth to print receipts"
+        "NFCReaderUsageDescription": "WPay uses NFC to accept contactless tap-to-pay and read payment cards and tags at checkout.",
+        "NSBluetoothAlwaysUsageDescription": "WPay uses Bluetooth to connect to a thermal receipt printer so you can print transaction receipts."
       },
       "entitlements": {
         "com.apple.developer.nfc.readersession.formats": ["TAG"]

--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -15,11 +15,7 @@
         "usesNonExemptEncryption": false
       },
       "infoPlist": {
-        "NFCReaderUsageDescription": "WPay uses NFC to accept contactless tap-to-pay and read payment cards and tags at checkout.",
         "NSBluetoothAlwaysUsageDescription": "WPay uses Bluetooth to connect to a thermal receipt printer so you can print transaction receipts."
-      },
-      "entitlements": {
-        "com.apple.developer.nfc.readersession.formats": ["TAG"]
       }
     },
     "android": {

--- a/dapps/pos-app/package.json
+++ b/dapps/pos-app/package.json
@@ -9,6 +9,7 @@
     "android:internal": "expo run:android --variant internal --app-id com.reown.mobilepos.internal",
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:build:internal": "cd android && ./gradlew assembleInternal",
+    "android:build:aab": "cd android && ./gradlew bundleRelease",
     "prebuild": "expo prebuild",
     "postprebuild": "node scripts/setup-secrets.js",
     "postinstall": "patch-package && npm run web:setup",


### PR DESCRIPTION
## What

Small improvements to the POS app.

### iOS — `app.json`
- Rewrote the **Bluetooth** Info.plist usage description to accurately describe how the app the capability (connecting to a thermal receipt printer). The previous string was an inaccurate placeholder.
- 
- **Removed `NSLocationWhenInUseUsageDescription`** — the app has no camera or location feature and no dependency declares or requests location (verified across `ios/Pods` and `node_modules`), so the key was dead.
- **Removed the iOS NFC entitlement (`com.apple.developer.nfc.readersession.formats`) and `NFCReaderUsageDescription`** — NFC is Android-only (HCE); there is no iOS CoreNFC code, so both were declared but unused. This does not change signing certificates (the app's entitlements stay a subset of the provisioning profile); at most a provisioning-profile refresh via fastlane match if the App ID's NFC capability is also disabled.

### Android — `package.json`
- Added an `android:build:aab` script (`gradlew bundleRelease`) to build an Android App Bundle. Output: `android/app/build/outputs/bundle/release/app-release.aab`.

## Notes
- Android NFC (HCE tap-to-pay) is **unchanged** — this only removes the unused *iOS* NFC declarations.
- No functional/runtime code changed — only build config and Info.plist/entitlement metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)