### PR TITLE
fix(pos-app): replace credentials toast with a log

### DIFF
--- a/dapps/pos-app/hooks/use-url-credentials.ts
+++ b/dapps/pos-app/hooks/use-url-credentials.ts
@@ -1,6 +1,5 @@
 import { useLogsStore } from "@/store/useLogsStore";
 import { useSettingsStore } from "@/store/useSettingsStore";
-import { showInfoToast } from "@/utils/toast";
 import { router } from "expo-router";
 import { useCallback, useEffect, useRef } from "react";
 import { Platform } from "react-native";
@@ -58,7 +57,7 @@ export function useUrlCredentials() {
           );
         }
 
-        showInfoToast("Credentials updated");
+        addLog("info", "Credentials updated", "layout", "useUrlCredentials");
         window.parent.postMessage({ type: "pos-credentials-updated" }, "*");
       } catch (error) {
         const errorMessage =


### PR DESCRIPTION
## What

When credentials are set up via URL params (or `postMessage`) on web, a bottom toast reading **"Credentials updated"** was shown. It used the app-wide `visibilityTime={2000}` and lingered on screen longer than needed for this event.

This removes that toast and instead records the event via `addLog("info", "Credentials updated", ...)` — a static, non-sensitive log line (no merchantId / API key). There was previously only per-field logging, so this keeps a single "credentials updated" trace.

## Notes

- The `pos-credentials-updated` `postMessage` to the parent window is unchanged (still asserted by tests).
- The global toast `visibilityTime` is untouched, so other toasts are unaffected.
- Removed the now-unused `showInfoToast` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)