### PR TITLE
feat(rn_cli_wallet): testnets setting + stop fetching testnet balances

### DIFF
--- a/wallets/rn_cli_wallet/src/constants/Eip155.ts
+++ b/wallets/rn_cli_wallet/src/constants/Eip155.ts
@@ -46,6 +46,7 @@ export const EIP155_CHAINS: Record<string, Chain> = {
     namespace: 'eip155',
     name: 'Avalanche Fuji',
     rpcUrl: 'https://api.avax-test.network/ext/bc/C/rpc',
+    isTestnet: true,
   },
   'eip155:56': {
     chainId: '56',
@@ -70,6 +71,7 @@ export const EIP155_CHAINS: Record<string, Chain> = {
     namespace: 'eip155',
     name: 'Optimism Sepholia',
     rpcUrl: 'https://sepolia.optimism.io',
+    isTestnet: true,
   },
   'eip155:137': {
     chainId: '137',

--- a/wallets/rn_cli_wallet/src/constants/Eip155.ts
+++ b/wallets/rn_cli_wallet/src/constants/Eip155.ts
@@ -69,7 +69,7 @@ export const EIP155_CHAINS: Record<string, Chain> = {
   'eip155:11155420': {
     chainId: '11155420',
     namespace: 'eip155',
-    name: 'Optimism Sepholia',
+    name: 'Optimism Sepolia',
     rpcUrl: 'https://sepolia.optimism.io',
     isTestnet: true,
   },

--- a/wallets/rn_cli_wallet/src/constants/Stellar.ts
+++ b/wallets/rn_cli_wallet/src/constants/Stellar.ts
@@ -52,6 +52,7 @@ export const STELLAR_TEST = {
     namespace: STELLAR_NAMESPACE,
     name: 'Stellar Testnet',
     rpcUrl: STELLAR_TESTNET_RPC,
+    isTestnet: true,
   },
 };
 

--- a/wallets/rn_cli_wallet/src/modals/SessionProposalModal.tsx
+++ b/wallets/rn_cli_wallet/src/modals/SessionProposalModal.tsx
@@ -13,6 +13,7 @@ import SettingsStore from '@/store/SettingsStore';
 import { handleRedirect } from '@/utils/LinkingUtils';
 import { RequestModal } from './RequestModal';
 import { getSupportedChains } from '@/utils/HelperUtil';
+import { ALL_CHAINS } from '@/utils/PresetsUtil';
 import { suiAddresses } from '@/utils/SuiWalletUtil';
 import { EIP155_CHAINS, EIP155_SIGNING_METHODS } from '@/constants/Eip155';
 import { SUI_CHAINS, SUI_EVENTS, SUI_SIGNING_METHODS } from '@/constants/Sui';
@@ -61,7 +62,9 @@ type AccordionType = 'app' | 'network' | null;
 
 export default function SessionProposalModal() {
   const { data } = useSnapshot(ModalStore.state);
-  const { currentRequestVerifyContext } = useSnapshot(SettingsStore.state);
+  const { currentRequestVerifyContext, testNets } = useSnapshot(
+    SettingsStore.state,
+  );
   const proposal =
     data?.proposal as SignClientTypes.EventArguments['session_proposal'];
 
@@ -79,7 +82,14 @@ export default function SessionProposalModal() {
   const isScam = currentRequestVerifyContext?.verified?.isScam;
 
   const supportedNamespaces = useMemo(() => {
-    const eip155Chains = Object.keys(EIP155_CHAINS);
+    // Testnet chains are only advertised to dapps when the "Testnets" setting is
+    // on (default off), so a mainnet-only wallet doesn't offer test networks.
+    const withoutTestnets = (chainIds: string[]) =>
+      testNets
+        ? chainIds
+        : chainIds.filter(id => !ALL_CHAINS[id]?.isTestnet);
+
+    const eip155Chains = withoutTestnets(Object.keys(EIP155_CHAINS));
     const eip155Methods = Object.values(EIP155_SIGNING_METHODS);
 
     const suiChains = Object.keys(SUI_CHAINS);
@@ -106,7 +116,7 @@ export default function SessionProposalModal() {
     const bip122Methods = Object.values(BIP122_SIGNING_METHODS);
     const bip122Events = Object.values(BIP122_EVENTS);
 
-    const stellarChains = Object.keys(STELLAR_CHAINS);
+    const stellarChains = withoutTestnets(Object.keys(STELLAR_CHAINS));
     const stellarMethods = Object.values(STELLAR_SIGNING_METHODS);
     const stellarEvents = Object.values(STELLAR_EVENTS);
 
@@ -175,7 +185,7 @@ export default function SessionProposalModal() {
           : [],
       },
     };
-  }, []);
+  }, [testNets]);
 
   const supportedChains = useMemo(() => {
     if (!proposal) {
@@ -186,6 +196,8 @@ export default function SessionProposalModal() {
       proposal.params.requiredNamespaces,
       proposal.params.optionalNamespaces,
     );
+    // getSupportedChains reads the current `testNets` setting internally; the
+    // toggle lives in Settings and can't change while this modal is open.
   }, [proposal]);
 
   // Initialize selected chains with all supported chains (only once)

--- a/wallets/rn_cli_wallet/src/screens/Settings/index.tsx
+++ b/wallets/rn_cli_wallet/src/screens/Settings/index.tsx
@@ -132,7 +132,7 @@ export default function Settings() {
           onToggle={toggleDarkMode}
         />
         <ToggleCard
-          label="Testnets"
+          label="Enable testnets"
           value={testNets}
           onToggle={() => SettingsStore.toggleTestNets()}
         />

--- a/wallets/rn_cli_wallet/src/screens/Settings/index.tsx
+++ b/wallets/rn_cli_wallet/src/screens/Settings/index.tsx
@@ -18,10 +18,17 @@ import { showToast } from '@/utils/ToastUtil';
 import { RootStackParamList } from '@/utils/TypesUtil';
 import { Button } from '@/components/Button';
 
-export default function Settings() {
-  const { socketStatus, themeMode } = useSnapshot(SettingsStore.state);
-  const [clientId, setClientId] = useState('');
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+// A settings row with a right-aligned toggle. Mirrors the card styling of the
+// other Settings rows.
+function ToggleCard({
+  label,
+  value,
+  onToggle,
+}: {
+  label: string;
+  value: boolean;
+  onToggle: () => void;
+}) {
   const Theme = useTheme();
 
   // react-native-web paints the Switch "on" state via activeTrackColor/
@@ -36,6 +43,55 @@ export default function Settings() {
         }
       : {}
   ) as { activeTrackColor?: string; activeThumbColor?: string };
+
+  return (
+    <Button
+      onPress={onToggle}
+      style={[
+        styles.switchCard,
+        { backgroundColor: Theme['foreground-primary'] },
+      ]}
+    >
+      <View style={styles.switchCardContent}>
+        <Text variant="md-500" color="text-primary">
+          {label}
+        </Text>
+        {/* On web the whole card (PressableScale) owns the toggle: a tap on
+            the switch bubbles up to the card, so if the Switch also fired
+            onValueChange it would toggle twice (net no change). Render it
+            display-only with pointerEvents="none" so the tap passes through.
+            On native there's no double-toggle, so keep the Switch fully
+            interactive (and accessible) with its own onValueChange. */}
+        {Platform.OS === 'web' ? (
+          <View pointerEvents="none" style={styles.switch}>
+            <Switch value={value} {...webAccentSwitchProps} />
+          </View>
+        ) : (
+          <Switch
+            value={value}
+            style={styles.switch}
+            onValueChange={onToggle}
+            trackColor={Platform.select({
+              android: {
+                false: Theme['foreground-tertiary'],
+                true: Theme['bg-accent-primary'],
+              },
+            })}
+            thumbColor={Platform.select({ android: Theme.white })}
+          />
+        )}
+      </View>
+    </Button>
+  );
+}
+
+export default function Settings() {
+  const { socketStatus, themeMode, testNets } = useSnapshot(
+    SettingsStore.state,
+  );
+  const [clientId, setClientId] = useState('');
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const Theme = useTheme();
 
   useEffect(() => {
     async function getAsyncData() {
@@ -70,43 +126,16 @@ export default function Settings() {
         Preferences
       </Text>
       <View style={styles.sectionContainer}>
-        <Button
-          onPress={toggleDarkMode}
-          style={[
-            styles.switchCard,
-            { backgroundColor: Theme['foreground-primary'] },
-          ]}
-        >
-          <View style={styles.switchCardContent}>
-            <Text variant="md-500" color="text-primary">
-              Dark mode
-            </Text>
-            {/* On web the whole card (PressableScale) owns the toggle: a tap on
-                the switch bubbles up to the card, so if the Switch also fired
-                onValueChange it would toggle twice (net no change). Render it
-                display-only with pointerEvents="none" so the tap passes through.
-                On native there's no double-toggle, so keep the Switch fully
-                interactive (and accessible) with its own onValueChange. */}
-            {Platform.OS === 'web' ? (
-              <View pointerEvents="none" style={styles.switch}>
-                <Switch value={themeMode === 'dark'} {...webAccentSwitchProps} />
-              </View>
-            ) : (
-              <Switch
-                value={themeMode === 'dark'}
-                style={styles.switch}
-                onValueChange={toggleDarkMode}
-                trackColor={Platform.select({
-                  android: {
-                    false: Theme['foreground-tertiary'],
-                    true: Theme['bg-accent-primary'],
-                  },
-                })}
-                thumbColor={Platform.select({ android: Theme.white })}
-              />
-            )}
-          </View>
-        </Button>
+        <ToggleCard
+          label="Dark mode"
+          value={themeMode === 'dark'}
+          onToggle={toggleDarkMode}
+        />
+        <ToggleCard
+          label="Testnets"
+          value={testNets}
+          onToggle={() => SettingsStore.toggleTestNets()}
+        />
         <Card
           title="Secret keys & phrases"
           onPress={() => navigation.navigate('SecretPhrase')}

--- a/wallets/rn_cli_wallet/src/store/SettingsStore.ts
+++ b/wallets/rn_cli_wallet/src/store/SettingsStore.ts
@@ -26,6 +26,13 @@ function getInitialThemeMode(): 'light' | 'dark' {
   return systemMode;
 }
 
+// `toggleTestNets` persists 'YES' via storage.setItem (JSON-encoded as '"YES"'),
+// so read it back the same way for a synchronous initial value.
+function getInitialTestNets(): boolean {
+  const saved = new MMKV().getString('TEST_NETS');
+  return saved === '"YES"' || saved === 'YES';
+}
+
 /**
  * Types
  */
@@ -67,7 +74,7 @@ interface State {
  * State
  */
 const state = proxy<State>({
-  testNets: false, //add async boolean
+  testNets: getInitialTestNets(),
   account: 0,
   activeChainId: '1',
   eip155Address: '',

--- a/wallets/rn_cli_wallet/src/store/WalletStore.ts
+++ b/wallets/rn_cli_wallet/src/store/WalletStore.ts
@@ -295,7 +295,12 @@ const WalletStore = {
 
     try {
       // Fetch all balances in parallel for better performance and resilience
-      const eip155ChainIds = Object.keys(EIP155_CHAINS);
+      // Only mainnets — the balance API is mainnet-only, and testnet chains
+      // (e.g. Sepolia) just return errors. Mirrors the mainnet-only *_SUPPORTED_CHAINS
+      // lists used by the other namespaces.
+      const eip155ChainIds = Object.entries(EIP155_CHAINS)
+        .filter(([, chain]) => !chain.isTestnet)
+        .map(([id]) => id);
 
       const [
         eip155Result,

--- a/wallets/rn_cli_wallet/src/utils/HelperUtil.ts
+++ b/wallets/rn_cli_wallet/src/utils/HelperUtil.ts
@@ -1,6 +1,7 @@
 import { isAddress, isHexString, toUtf8String } from 'ethers';
 import { ProposalTypes } from '@walletconnect/types';
 import { PresetsUtil } from './PresetsUtil';
+import SettingsStore from '@/store/SettingsStore';
 
 /**
  * Truncates string (in the middle) via given lenght value
@@ -124,7 +125,12 @@ export function getSupportedChains(
 
   const chains = [...required.flat(), ...optional.flat()];
 
+  // Hide testnet networks from the connect flow unless the user has opted in via
+  // the "Testnets" setting.
+  const testNetsEnabled = SettingsStore.state.testNets;
+
   return chains
     .map(chain => PresetsUtil.getChainDataById(chain))
-    .filter(chain => chain !== undefined);
+    .filter(chain => chain !== undefined)
+    .filter(chain => testNetsEnabled || !chain?.isTestnet);
 }

--- a/wallets/rn_cli_wallet/src/utils/PresetsUtil.ts
+++ b/wallets/rn_cli_wallet/src/utils/PresetsUtil.ts
@@ -1,4 +1,5 @@
 import { ImageSourcePropType } from 'react-native';
+import { Chain } from '@/utils/TypesUtil';
 import { TON_CHAINS, TON_NETWORKS_IMAGES } from '@/constants/Ton';
 import { SUI_CHAINS, SUI_NETWORKS_IMAGES } from '@/constants/Sui';
 import { EIP155_CHAINS, EIP155_NETWORK_IMAGES } from '@/constants/Eip155';
@@ -19,7 +20,7 @@ const NetworkImages: Record<string, ImageSourcePropType> = {
   ...STELLAR_NETWORKS_IMAGES,
 };
 
-export const ALL_CHAINS = {
+export const ALL_CHAINS: Record<string, Chain> = {
   ...EIP155_CHAINS,
   ...SUI_CHAINS,
   ...TON_CHAINS,

--- a/wallets/rn_cli_wallet/src/utils/TypesUtil.ts
+++ b/wallets/rn_cli_wallet/src/utils/TypesUtil.ts
@@ -89,6 +89,9 @@ export type Chain = {
   name: string;
   namespace: string;
   rpcUrl: string;
+  // Testnet chains are only advertised to dapps when the "Testnets" setting is
+  // on, and are never queried for balances (the balance API is mainnet-only).
+  isTestnet?: boolean;
 };
 
 // Payment Modal Flow


### PR DESCRIPTION
> Stacked on #590 (base = `feat/stellar-rn-cli-wallet`). Will retarget to `main` once #590 merges.

## Description

Follow-up to the Stellar PR, addressing the testnet questions that came up there:
1. **Do we fetch balances for testnets?** We shouldn't — the balance API is mainnet-only and testnet chains only return errors (the recurring Optimism Sepolia `503`/LogBox noise).
2. **Do we advertise testnets to dapps?** Only when the user opts in — this wires up the previously **dead** `testNets` setting.

## Changes

- **`Chain.isTestnet` flag** (`TypesUtil`) — marks the test networks: EVM **Avalanche Fuji** (`43113`) and **Optimism Sepolia** (`11155420`), and **Stellar testnet**. (Only 2 of the 22 EVM chains are actually testnets.)
- **Balances** (`WalletStore`) — the EVM fetch now filters out `isTestnet` chains, mirroring the mainnet-only `*_SUPPORTED_CHAINS` lists the other namespaces already use.
- **Connect flow** — `SessionProposalModal` advertises testnet chains, and `getSupportedChains` surfaces them in the network selector, **only when `testNets` is on** (default off). A testnet-only dapp gets "network not supported" when it's off.
- **Settings** — adds a persisted **"Testnets"** switch (loaded synchronously on startup) next to Dark mode; extracts the shared switch row into a local `ToggleCard` to avoid duplicating the web/native `Switch` handling.

## Where testnets surface (for reviewers)
There's no dedicated networks screen — a testnet is only visible in the **connect modal's network selector** when a dapp requests it, and via the **advertised namespaces**. The toggle gates both.

## Out of scope
Several EVM `503`s came from niche **mainnets** the balance API doesn't cover (Evmos, Filecoin, IoTeX, Metis, Moonbeam/river) — a separate cleanup (trim to API-supported mainnets, or downgrade `503`→warn).

## Testing
- `tsc --noEmit` clean; `eslint` clean.
- Behavior: default (testnets off) — no testnet balance calls, testnet chains not advertised; toggle on — testnets appear in the connect selector again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)