### PR TITLE
feat(pos-app): improve tablet layouts

### DIFF
--- a/dapps/pos-app/__tests__/hooks/use-is-tablet.test.ts
+++ b/dapps/pos-app/__tests__/hooks/use-is-tablet.test.ts
@@ -1,0 +1,31 @@
+import { isTablet } from "react-native-device-info";
+
+import { getIsTablet } from "@/hooks/use-is-tablet";
+
+const mockIsTablet = jest.mocked(isTablet);
+
+describe("getIsTablet", () => {
+  beforeEach(() => {
+    mockIsTablet.mockReset();
+    mockIsTablet.mockReturnValue(false);
+  });
+
+  it("uses the native device classification on iOS and Android", () => {
+    mockIsTablet.mockReturnValue(true);
+
+    expect(getIsTablet("ios")).toBe(true);
+    expect(getIsTablet("android")).toBe(true);
+    expect(mockIsTablet).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns false for native handsets", () => {
+    expect(getIsTablet("ios")).toBe(false);
+  });
+
+  it("always returns false on web without querying device info", () => {
+    mockIsTablet.mockReturnValue(true);
+
+    expect(getIsTablet("web")).toBe(false);
+    expect(mockIsTablet).not.toHaveBeenCalled();
+  });
+});

--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -36,7 +36,7 @@
         "android.permission.BLUETOOTH_ADVERTISE",
         "android.permission.USB_PERMISSION"
       ],
-      "versionCode": 30
+      "versionCode": 31
     },
     "web": {
       "output": "static",

--- a/dapps/pos-app/app/amount.tsx
+++ b/dapps/pos-app/app/amount.tsx
@@ -2,6 +2,7 @@ import { BigAmountInput } from "@/components/big-amount-input";
 import { Button } from "@/components/button";
 import { NumericKeyboard } from "@/components/numeric-keyboard";
 import { Spacing } from "@/constants/spacing";
+import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useTheme } from "@/hooks/use-theme-color";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import {
@@ -36,6 +37,7 @@ const formatAmount = (amount: string) => {
 
 export default function AmountScreen() {
   const Theme = useTheme();
+  const isTablet = useIsTablet();
   const currencyCode = useSettingsStore((state) => state.currency);
   const currency = getCurrency(currencyCode);
   const {
@@ -61,7 +63,7 @@ export default function AmountScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, isTablet && styles.containerTablet]}>
       <View
         style={[
           styles.amountContainer,
@@ -73,6 +75,7 @@ export default function AmountScreen() {
           value={watchAmount}
           currency={currency.symbol}
           symbolPosition={currency.symbolPosition}
+          size={isTablet ? "lg" : "md"}
         />
       </View>
       <Controller
@@ -126,7 +129,8 @@ export default function AmountScreen() {
         testID="charge-button"
         onPress={handleSubmit(onSubmit)}
         disabled={!isValid}
-        style={styles.button}
+        size={isTablet ? "lg" : "md"}
+        style={[styles.button, isTablet && styles.buttonTablet]}
       >
         {isValid
           ? `Charge ${formatAmountWithSymbol(formatAmount(watchAmount), currency)}`
@@ -145,6 +149,10 @@ const styles = StyleSheet.create({
     paddingTop: Spacing["spacing-5"],
     paddingBottom: Platform.OS === "web" ? 0 : Spacing["spacing-5"],
   },
+  containerTablet: {
+    paddingHorizontal: Spacing["spacing-8"],
+    paddingTop: Spacing["spacing-8"],
+  },
   amountContainer: {
     flex: 1,
     width: "100%",
@@ -155,5 +163,8 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: Spacing["spacing-6"],
+  },
+  buttonTablet: {
+    marginTop: Spacing["spacing-8"],
   },
 });

--- a/dapps/pos-app/app/index.tsx
+++ b/dapps/pos-app/app/index.tsx
@@ -1,6 +1,7 @@
 import { Pressable } from "@/components/pressable";
 import { ThemedText } from "@/components/themed-text";
 import { BorderRadius, Spacing } from "@/constants/spacing";
+import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useTheme } from "@/hooks/use-theme-color";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import { showErrorToast } from "@/utils/toast";
@@ -31,6 +32,7 @@ export default function HomeScreen() {
   ]);
 
   const Theme = useTheme();
+  const isTablet = useIsTablet();
   const { height: windowHeight } = useWindowDimensions();
   const { bottom } = useSafeAreaInsets();
   const [contentWidth, setContentWidth] = useState(0);
@@ -58,7 +60,17 @@ export default function HomeScreen() {
   };
 
   const isCompact = windowHeight < compactScreenHeight;
-  const secondaryActionHeight = isCompact ? 112 : 140;
+  const horizontalPadding = isTablet
+    ? Spacing["spacing-8"]
+    : Spacing["spacing-5"];
+  const actionGap = isTablet ? Spacing["spacing-6"] : Spacing["spacing-3"];
+  const secondaryActionSize = isTablet
+    ? contentWidth
+      ? Math.round((contentWidth - actionGap) / 2)
+      : 140
+    : isCompact
+      ? 112
+      : 140;
   const primaryActionMinHeight = isCompact ? 200 : 320;
   // Cap the button's height from its actual measured width (the container's
   // content box, via onLayout) so the near-square rule holds regardless of the
@@ -70,15 +82,25 @@ export default function HomeScreen() {
         Math.round(contentWidth * primaryMaxAspectRatio),
       )
     : undefined;
-  const topSpacing = Spacing["spacing-6"];
+  const topSpacing = isTablet ? Spacing["spacing-11"] : Spacing["spacing-6"];
+  const actionLabelSize = isTablet ? 24 : 18;
+  const actionLabelLineHeight = isTablet ? 28 : undefined;
+  const secondaryActionDimensions = isTablet
+    ? {
+        flex: 0,
+        width: secondaryActionSize,
+        height: secondaryActionSize,
+      }
+    : undefined;
 
   const handleContentLayout = (event: LayoutChangeEvent) => {
     // Content box width = full width minus the container's horizontal padding,
     // which matches the full-width button's width.
-    const measured = event.nativeEvent.layout.width - Spacing["spacing-5"] * 2;
-    if (measured > 0 && measured !== contentWidth) {
-      setContentWidth(measured);
-    }
+    const measured = event.nativeEvent.layout.width - horizontalPadding * 2;
+    if (measured <= 0) return;
+    setContentWidth((currentWidth) =>
+      currentWidth === measured ? currentWidth : measured,
+    );
   };
   const bottomSpacing = Math.max(
     bottom + Spacing["spacing-3"],
@@ -90,7 +112,12 @@ export default function HomeScreen() {
       onLayout={handleContentLayout}
       style={[
         styles.container,
-        { paddingTop: topSpacing, paddingBottom: bottomSpacing },
+        {
+          paddingHorizontal: horizontalPadding,
+          paddingTop: topSpacing,
+          paddingBottom: bottomSpacing,
+          gap: actionGap,
+        },
       ]}
     >
       <Pressable
@@ -111,17 +138,27 @@ export default function HomeScreen() {
       >
         <Image
           source={assets?.[0]}
-          style={styles.actionButtonImage}
+          style={[
+            styles.actionButtonImage,
+            isTablet && styles.actionButtonImageTablet,
+          ]}
           tintColor={Theme["icon-invert"]}
           cachePolicy="memory-disk"
           priority="high"
         />
-        <ThemedText style={{ fontWeight: 500 }} fontSize={18}>
+        <ThemedText
+          style={{ fontWeight: 500 }}
+          fontSize={actionLabelSize}
+          lineHeight={actionLabelLineHeight}
+        >
           New payment
         </ThemedText>
       </Pressable>
       <View
-        style={[styles.secondaryActions, { height: secondaryActionHeight }]}
+        style={[
+          styles.secondaryActions,
+          { height: secondaryActionSize, gap: actionGap },
+        ]}
       >
         <Pressable
           testID="activity-button"
@@ -131,18 +168,27 @@ export default function HomeScreen() {
           onPress={handleActivityPress}
           style={[
             styles.actionButton,
+            secondaryActionDimensions,
             styles.baseActionButton,
             { backgroundColor: Theme["foreground-primary-fix"] },
           ]}
         >
           <Image
             source={assets?.[1]}
-            style={styles.actionButtonImage}
+            style={[
+              styles.actionButtonImage,
+              isTablet && styles.actionButtonImageTablet,
+            ]}
             tintColor={Theme["icon-invert"]}
             cachePolicy="memory-disk"
             priority="high"
           />
-          <ThemedText fontSize={18}>Transactions</ThemedText>
+          <ThemedText
+            fontSize={actionLabelSize}
+            lineHeight={actionLabelLineHeight}
+          >
+            Transactions
+          </ThemedText>
         </Pressable>
         <Pressable
           testID="settings-button"
@@ -153,17 +199,26 @@ export default function HomeScreen() {
           style={[
             styles.baseActionButton,
             styles.actionButton,
+            secondaryActionDimensions,
             { backgroundColor: Theme["foreground-primary-fix"] },
           ]}
         >
           <Image
             source={assets?.[2]}
-            style={styles.actionButtonImage}
+            style={[
+              styles.actionButtonImage,
+              isTablet && styles.actionButtonImageTablet,
+            ]}
             tintColor={Theme["icon-invert"]}
             cachePolicy="memory-disk"
             priority="high"
           />
-          <ThemedText fontSize={18}>Settings</ThemedText>
+          <ThemedText
+            fontSize={actionLabelSize}
+            lineHeight={actionLabelLineHeight}
+          >
+            Settings
+          </ThemedText>
         </Pressable>
       </View>
     </View>
@@ -174,10 +229,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     width: "100%",
-    paddingHorizontal: Spacing["spacing-5"],
     alignItems: "center",
     justifyContent: "flex-end",
-    gap: Spacing["spacing-3"],
   },
   baseActionButton: {
     justifyContent: "center",
@@ -195,10 +248,13 @@ const styles = StyleSheet.create({
   secondaryActions: {
     flexDirection: "row",
     width: "100%",
-    gap: Spacing["spacing-3"],
   },
   actionButtonImage: {
     width: 32,
     height: 32,
+  },
+  actionButtonImageTablet: {
+    width: 48,
+    height: 48,
   },
 });

--- a/dapps/pos-app/app/payment-failure.tsx
+++ b/dapps/pos-app/app/payment-failure.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button } from "@/components/button";
 import { ThemedText } from "@/components/themed-text";
 import { Spacing } from "@/constants/spacing";
+import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useTheme } from "@/hooks/use-theme-color";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import {
@@ -27,6 +28,7 @@ interface ScreenParams extends UnknownOutputParams {
 
 export default function PaymentFailureScreen() {
   const Theme = useTheme();
+  const isTablet = useIsTablet();
   const { top } = useSafeAreaInsets();
   const params: Partial<ScreenParams> = useLocalSearchParams<ScreenParams>();
   const currencyCode = useSettingsStore((state) => state.currency);
@@ -55,16 +57,23 @@ export default function PaymentFailureScreen() {
   };
 
   return (
-    <View style={[styles.container, { paddingTop: top }]}>
+    <View
+      style={[
+        styles.container,
+        isTablet && styles.containerTablet,
+        { paddingTop: top },
+      ]}
+    >
       <View
         testID="pos-payment-failure"
         nativeID="pos-payment-failure"
-        style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
+        style={styles.failureContent}
       >
         <Image
           source={assets?.[0]}
           style={[
             styles.warningCircle,
+            isTablet && styles.warningCircleTablet,
             { tintColor: Theme["bg-accent-primary"] },
           ]}
           cachePolicy="memory-disk"
@@ -72,17 +81,30 @@ export default function PaymentFailureScreen() {
           priority="high"
         />
         <ThemedText
-          style={[styles.failedText, { color: Theme["text-primary"] }]}
+          style={[
+            styles.failedText,
+            isTablet && styles.failedTextTablet,
+            { color: Theme["text-primary"] },
+          ]}
         >
           {title}
         </ThemedText>
         <ThemedText
-          style={[styles.failedDescription, { color: Theme["text-tertiary"] }]}
+          style={[
+            styles.failedDescription,
+            isTablet && styles.failedDescriptionTablet,
+            { color: Theme["text-tertiary"] },
+          ]}
         >
           {subtitle}
         </ThemedText>
       </View>
-      <Button type="accent" variant="primary" onPress={handlePrimaryPress}>
+      <Button
+        type="accent"
+        variant="primary"
+        size={isTablet ? "lg" : "md"}
+        onPress={handlePrimaryPress}
+      >
         {isInvalidApiKey ? "Go to Settings" : "Start new payment"}
       </Button>
     </View>
@@ -95,11 +117,25 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing["spacing-5"],
     paddingBottom: Platform.OS === "web" ? 0 : Spacing["spacing-5"],
   },
+  containerTablet: {
+    paddingHorizontal: Spacing["spacing-8"],
+    paddingBottom: Spacing["spacing-8"],
+  },
+  failureContent: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
   failedText: {
     fontSize: 20,
     lineHeight: 20,
     textAlign: "center",
     marginBottom: Spacing["spacing-3"],
+  },
+  failedTextTablet: {
+    fontSize: 28,
+    lineHeight: 32,
+    marginBottom: Spacing["spacing-5"],
   },
   failedDescription: {
     fontSize: 16,
@@ -107,9 +143,20 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginBottom: Spacing["spacing-3"],
   },
+  failedDescriptionTablet: {
+    maxWidth: 640,
+    fontSize: 20,
+    lineHeight: 24,
+    marginBottom: Spacing["spacing-5"],
+  },
   warningCircle: {
     width: 48,
     height: 48,
     marginBottom: Spacing["spacing-6"],
+  },
+  warningCircleTablet: {
+    width: 72,
+    height: 72,
+    marginBottom: Spacing["spacing-8"],
   },
 });

--- a/dapps/pos-app/app/payment-success.tsx
+++ b/dapps/pos-app/app/payment-success.tsx
@@ -15,6 +15,7 @@ import { SuccessAnimation } from "@/components/success-animation";
 import { ThemedText } from "@/components/themed-text";
 import { Spacing } from "@/constants/spacing";
 import { useDisableBackButton } from "@/hooks/use-disable-back-button";
+import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useTheme } from "@/hooks/use-theme-color";
 import { useLogsStore } from "@/store/useLogsStore";
 import { useSettingsStore } from "@/store/useSettingsStore";
@@ -46,6 +47,7 @@ const contentRevealDuration = 200;
 export default function PaymentSuccessScreen() {
   useDisableBackButton();
   const Theme = useTheme();
+  const isTablet = useIsTablet();
   const params = useLocalSearchParams<SuccessParams>();
   const themeMode = useSettingsStore((state) => state.themeMode);
   const currencyCode = useSettingsStore((state) => state.currency);
@@ -208,6 +210,7 @@ export default function PaymentSuccessScreen() {
       <Animated.View
         style={[
           styles.contentContainer,
+          isTablet && styles.contentContainerTablet,
           {
             paddingTop: top + Spacing["spacing-3"],
             paddingBottom: bottomSpacing,
@@ -221,44 +224,59 @@ export default function PaymentSuccessScreen() {
         <View
           testID="pos-payment-success"
           nativeID="pos-payment-success"
-          style={{
-            flex: 1,
-            justifyContent: "center",
-            alignItems: "center",
-            gap: Spacing["spacing-2"],
-          }}
+          style={[
+            styles.successContent,
+            isTablet && styles.successContentTablet,
+          ]}
         >
-          <View style={styles.successAnimationContainer}>
+          <View
+            style={[
+              styles.successAnimationContainer,
+              isTablet && styles.successAnimationContainerTablet,
+            ]}
+          >
             {isSuccessAnimationVisible && (
-              <SuccessAnimation width={200} height={175} />
+              <SuccessAnimation
+                width={isTablet ? 280 : 200}
+                height={isTablet ? 245 : 175}
+              />
             )}
           </View>
           <ThemedText
-            fontSize={38}
-            lineHeight={38}
+            fontSize={isTablet ? 52 : 38}
+            lineHeight={isTablet ? 54 : 38}
             style={[styles.amountValue, { color: Theme["text-primary"] }]}
           >
             {formatAmountWithSymbol(amount, currency)}
           </ThemedText>
           <ThemedText
-            fontSize={18}
-            lineHeight={20}
+            fontSize={isTablet ? 24 : 18}
+            lineHeight={isTablet ? 28 : 20}
             style={[styles.amountDescription, { color: Theme["text-primary"] }]}
           >
             Payment successful
           </ThemedText>
         </View>
-        <View style={styles.buttonContainer}>
+        <View
+          style={[
+            styles.buttonContainer,
+            isTablet && styles.buttonContainerTablet,
+          ]}
+        >
           {isPrinterConnected && (
             <Button
               type="neutral"
               variant="tertiary"
               onPress={handlePrintReceipt}
               disabled={isPrinting}
+              size={isTablet ? "lg" : "md"}
               icon={
                 <Image
                   source={require("@/assets/images/receipt.png")}
-                  style={styles.buttonIcon}
+                  style={[
+                    styles.buttonIcon,
+                    isTablet && styles.buttonIconTablet,
+                  ]}
                   tintColor={Theme["bg-primary"]}
                 />
               }
@@ -267,7 +285,12 @@ export default function PaymentSuccessScreen() {
             </Button>
           )}
 
-          <Button type="accent" variant="primary" onPress={handleNewPayment}>
+          <Button
+            type="accent"
+            variant="primary"
+            size={isTablet ? "lg" : "md"}
+            onPress={handleNewPayment}
+          >
             Start new payment
           </Button>
         </View>
@@ -305,6 +328,9 @@ const styles = StyleSheet.create({
     width: "100%",
     paddingHorizontal: Spacing["spacing-5"],
   },
+  contentContainerTablet: {
+    paddingHorizontal: Spacing["spacing-8"],
+  },
   header: {
     alignItems: "center",
     paddingBottom: Spacing["spacing-4"],
@@ -312,6 +338,19 @@ const styles = StyleSheet.create({
   successAnimationContainer: {
     width: 200,
     height: 175,
+  },
+  successAnimationContainerTablet: {
+    width: 280,
+    height: 245,
+  },
+  successContent: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: Spacing["spacing-2"],
+  },
+  successContentTablet: {
+    gap: Spacing["spacing-4"],
   },
   amountDescription: {
     textAlign: "center",
@@ -323,8 +362,15 @@ const styles = StyleSheet.create({
     width: "100%",
     gap: Spacing["spacing-3"],
   },
+  buttonContainerTablet: {
+    gap: Spacing["spacing-5"],
+  },
   buttonIcon: {
     width: 16,
     height: 16,
+  },
+  buttonIconTablet: {
+    width: 20,
+    height: 20,
   },
 });

--- a/dapps/pos-app/app/scan.tsx
+++ b/dapps/pos-app/app/scan.tsx
@@ -4,6 +4,7 @@ import { ThemedText } from "@/components/themed-text";
 import { WalletConnectLoading } from "@/components/walletconnect-loading";
 import { Spacing } from "@/constants/spacing";
 import { useCountdown } from "@/hooks/use-countdown";
+import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useNfcPayment } from "@/hooks/use-nfc-payment";
 import { useTheme } from "@/hooks/use-theme-color";
 import { usePaymentStatus } from "@/services/hooks";
@@ -60,6 +61,7 @@ export default function ScanScreen() {
   const currency = getCurrency(currencyCode);
   const addLog = useLogsStore((state) => state.addLog);
   const Theme = useTheme();
+  const isTablet = useIsTablet();
 
   const { amount } = params;
 
@@ -266,38 +268,56 @@ export default function ScanScreen() {
         }}
       />
       {isProcessing ? (
-        <View style={styles.loadingContainer}>
-          <WalletConnectLoading size={180} />
+        <View
+          style={[
+            styles.loadingContainer,
+            isTablet && styles.loadingContainerTablet,
+          ]}
+        >
+          <WalletConnectLoading size={isTablet ? 220 : 180} />
           <View style={styles.loadingTextContainer}>
             <ThemedText
               style={{ color: Theme["text-primary"] }}
-              fontSize={20}
-              lineHeight={22}
+              fontSize={isTablet ? 24 : 20}
+              lineHeight={isTablet ? 26 : 22}
             >
               Waiting for confirmation...
             </ThemedText>
             <ThemedText
               style={{ color: Theme["text-secondary"], textAlign: "center" }}
-              fontSize={16}
-              lineHeight={18}
+              fontSize={isTablet ? 20 : 16}
+              lineHeight={isTablet ? 22 : 18}
             >
               This usually takes a few seconds. Keep this screen open.
             </ThemedText>
           </View>
         </View>
       ) : (
-        <View style={styles.scanContainer}>
-          <View style={[styles.header, !showNfc && styles.headerCentered]}>
+        <View
+          style={[styles.scanContainer, isTablet && styles.scanContainerTablet]}
+        >
+          <View
+            style={[
+              styles.header,
+              isTablet && styles.headerTablet,
+              !showNfc && styles.headerCentered,
+            ]}
+          >
             {showNfc && (
               <Image
                 source={assets?.[1]}
                 contentFit="contain"
-                style={[styles.nfcIcon, { tintColor: Theme["icon-default"] }]}
+                style={[
+                  styles.nfcIcon,
+                  isTablet && styles.nfcIconTablet,
+                  { tintColor: Theme["icon-default"] },
+                ]}
               />
             )}
             <ThemedText
               style={[
                 styles.amountValue,
+                isTablet && styles.amountValueTablet,
                 { color: Theme["text-primary"], textTransform: "uppercase" },
               ]}
             >
@@ -306,20 +326,27 @@ export default function ScanScreen() {
           </View>
 
           <ThemedText
-            style={[styles.instructionText, { color: Theme["text-secondary"] }]}
+            style={[
+              styles.instructionText,
+              isTablet && styles.instructionTextTablet,
+              { color: Theme["text-secondary"] },
+            ]}
           >
             {showNfc ? "Scan or tap to pay" : "Scan to pay"}
           </ThemedText>
 
-          <View style={styles.qrSection}>
+          <View style={[styles.qrSection, isTablet && styles.qrSectionTablet]}>
             <QRCode
-              size={300}
+              size={isTablet ? 420 : 300}
               uri={qrUri}
               logoBorderRadius={100}
               onPress={handleCopyPaymentUrl}
               testID="pos-qr-code"
             >
-              <Image source={assets?.[0]} style={styles.logo} />
+              <Image
+                source={assets?.[0]}
+                style={[styles.logo, isTablet && styles.logoTablet]}
+              />
             </QRCode>
             <View
               accessible={isCountdownActive}
@@ -341,10 +368,16 @@ export default function ScanScreen() {
               }
               style={[styles.timerRow, { opacity: isCountdownActive ? 1 : 0 }]}
             >
-              <ThemedText style={{ color: Theme["text-secondary"] }}>
+              <ThemedText
+                fontSize={isTablet ? 20 : undefined}
+                lineHeight={isTablet ? 22 : undefined}
+                style={{ color: Theme["text-secondary"] }}
+              >
                 Expires in
               </ThemedText>
               <ThemedText
+                fontSize={isTablet ? 20 : undefined}
+                lineHeight={isTablet ? 22 : undefined}
                 style={{
                   color: Theme["bg-accent-primary"],
                   fontVariant: ["tabular-nums"],
@@ -364,7 +397,8 @@ export default function ScanScreen() {
           testID="cancel-button"
           onPress={handleOnCancelPress}
           fullWidth={false}
-          style={styles.cancelButton}
+          size={isTablet ? "lg" : "md"}
+          style={[styles.cancelButton, isTablet && styles.cancelButtonTablet]}
         >
           Cancel
         </Button>
@@ -384,6 +418,10 @@ const styles = StyleSheet.create({
     gap: Spacing["spacing-6"],
     paddingHorizontal: Spacing["spacing-7"],
   },
+  loadingContainerTablet: {
+    gap: Spacing["spacing-8"],
+    paddingHorizontal: Spacing["spacing-8"],
+  },
   scanContainer: {
     flex: 1,
     paddingHorizontal: Spacing["spacing-5"],
@@ -391,10 +429,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: Spacing["spacing-4"],
   },
+  scanContainerTablet: {
+    paddingHorizontal: Spacing["spacing-8"],
+    paddingVertical: Spacing["spacing-8"],
+    gap: Spacing["spacing-5"],
+  },
   header: {
     width: "100%",
     alignItems: "center",
     gap: Spacing["spacing-3"],
+  },
+  headerTablet: {
+    gap: Spacing["spacing-5"],
   },
   headerCentered: {
     flex: 1,
@@ -408,6 +454,10 @@ const styles = StyleSheet.create({
     fontSize: 18,
     textAlign: "center",
   },
+  instructionTextTablet: {
+    fontSize: 22,
+    lineHeight: 24,
+  },
   amountValue: {
     fontFamily: "KH Teka Medium",
     fontSize: 50,
@@ -415,13 +465,24 @@ const styles = StyleSheet.create({
     letterSpacing: -1,
     lineHeight: 50,
   },
+  amountValueTablet: {
+    fontSize: 64,
+    lineHeight: 64,
+  },
   logo: {
     width: 80,
     height: 80,
   },
+  logoTablet: {
+    width: 104,
+    height: 104,
+  },
   qrSection: {
     alignItems: "center",
     gap: Spacing["spacing-4"],
+  },
+  qrSectionTablet: {
+    gap: Spacing["spacing-5"],
   },
   timerRow: {
     flexDirection: "row",
@@ -432,10 +493,19 @@ const styles = StyleSheet.create({
   cancelButton: {
     marginHorizontal: Spacing["spacing-5"],
   },
+  cancelButtonTablet: {
+    marginHorizontal: Spacing["spacing-8"],
+  },
   nfcIcon: {
     marginLeft: Spacing["spacing-5"],
     width: 80,
     height: 60,
     marginBottom: Spacing["spacing-3"],
+  },
+  nfcIconTablet: {
+    marginLeft: Spacing["spacing-8"],
+    width: 104,
+    height: 78,
+    marginBottom: Spacing["spacing-5"],
   },
 });

--- a/dapps/pos-app/components/big-amount-input/BigAmountInput.tsx
+++ b/dapps/pos-app/components/big-amount-input/BigAmountInput.tsx
@@ -12,17 +12,22 @@ export const BigAmountInput = ({
   symbolPosition = "left",
   locale,
   placeholder = "0.00",
+  size = "md",
   testID,
   style,
 }: BigAmountInputProps) => {
   return (
-    <View style={[styles.container, style]} testID={testID}>
+    <View
+      style={[styles.container, size === "lg" && styles.containerLarge, style]}
+      testID={testID}
+    >
       <AnimatedNumber
         value={value}
         currency={currency}
         symbolPosition={symbolPosition}
         locale={locale}
         placeholder={placeholder}
+        size={size}
       />
     </View>
   );
@@ -35,5 +40,8 @@ const styles = StyleSheet.create({
     minHeight: 80,
     flex: 1,
     width: "100%",
+  },
+  containerLarge: {
+    minHeight: 100,
   },
 });

--- a/dapps/pos-app/components/big-amount-input/BigAmountInput.types.ts
+++ b/dapps/pos-app/components/big-amount-input/BigAmountInput.types.ts
@@ -24,6 +24,10 @@ export type BigAmountInputProps = {
    */
   placeholder?: string;
   /**
+   * Visual size of the amount display. The large size is intended for tablets.
+   */
+  size?: "md" | "lg";
+  /**
    * Test ID for testing
    */
   testID?: string;

--- a/dapps/pos-app/components/big-amount-input/components/AnimatedCharacter.tsx
+++ b/dapps/pos-app/components/big-amount-input/components/AnimatedCharacter.tsx
@@ -31,6 +31,7 @@ type AnimatedCharacterProps = {
   scale: number;
   characterWidth: number;
   itemHeight: number;
+  fontSize: number;
   positionX: number;
   isPlaceholder?: boolean;
   textPrimaryColor: string;
@@ -43,6 +44,7 @@ function AnimatedCharacterComponent({
   scale,
   characterWidth,
   itemHeight,
+  fontSize,
   positionX,
   isPlaceholder = false,
   textPrimaryColor,
@@ -111,7 +113,7 @@ function AnimatedCharacterComponent({
           animatedStyle,
         ]}
       >
-        <Animated.Text style={[styles.text, { color: textColor }]}>
+        <Animated.Text style={[styles.text, { color: textColor, fontSize }]}>
           {item.char}
         </Animated.Text>
       </Animated.View>
@@ -128,7 +130,6 @@ const styles = StyleSheet.create({
   },
   text: {
     fontFamily: "KH Teka Medium",
-    fontSize: 64,
     letterSpacing: -1,
     position: "absolute",
     textAlign: "center",

--- a/dapps/pos-app/components/big-amount-input/components/AnimatedNumber.tsx
+++ b/dapps/pos-app/components/big-amount-input/components/AnimatedNumber.tsx
@@ -20,6 +20,7 @@ type AnimatedNumberProps = {
   symbolPosition?: SymbolPosition;
   locale?: SupportedLocale;
   placeholder?: string;
+  size?: "md" | "lg";
 };
 
 export const AnimatedNumber = ({
@@ -28,6 +29,7 @@ export const AnimatedNumber = ({
   symbolPosition = "left",
   locale,
   placeholder = "0.00",
+  size = "md",
 }: AnimatedNumberProps) => {
   const Theme = useTheme();
   const { characters, separators, isEmpty, decimalSeparator } =
@@ -38,7 +40,7 @@ export const AnimatedNumber = ({
       locale,
       placeholder,
     });
-  const layout = useAnimatedNumberLayout({ characters, separators });
+  const layout = useAnimatedNumberLayout({ characters, separators, size });
 
   const animatedWidth = useSharedValue(layout.totalContentWidth);
 

--- a/dapps/pos-app/components/big-amount-input/components/AnimatedNumberCharacters.tsx
+++ b/dapps/pos-app/components/big-amount-input/components/AnimatedNumberCharacters.tsx
@@ -45,6 +45,7 @@ function CharacterGroupComponent({
         scale={layout.scale}
         characterWidth={charLayout.width}
         itemHeight={layout.itemHeight}
+        fontSize={layout.fontSize}
         positionX={charLayout.position}
         isPlaceholder={isEmpty}
         textPrimaryColor={textPrimaryColor}
@@ -57,6 +58,7 @@ function CharacterGroupComponent({
           scale={layout.scale}
           characterWidth={layout.getCharWidth(separator)}
           itemHeight={layout.itemHeight}
+          fontSize={layout.fontSize}
           positionX={charLayout.position + charLayout.spacingWidth}
           isPlaceholder={isEmpty}
           textPrimaryColor={textPrimaryColor}

--- a/dapps/pos-app/components/big-amount-input/hooks/useAnimatedNumberLayout.test.ts
+++ b/dapps/pos-app/components/big-amount-input/hooks/useAnimatedNumberLayout.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { getCharactersArray } from "../utils/getCharactersArray";
+import { useAnimatedNumberLayout } from "./useAnimatedNumberLayout";
+
+describe("useAnimatedNumberLayout", () => {
+  it("preserves the existing medium metrics", () => {
+    const parsed = getCharactersArray("$123.45");
+    const { result } = renderHook(() =>
+      useAnimatedNumberLayout({ ...parsed, size: "md" }),
+    );
+
+    expect(result.current.fontSize).toBe(64);
+    expect(result.current.itemHeight).toBe(60);
+    expect(result.current.scale).toBe(1);
+  });
+
+  it("scales every layout metric proportionally for tablets", () => {
+    const parsed = getCharactersArray("$123.45");
+    const medium = renderHook(() =>
+      useAnimatedNumberLayout({ ...parsed, size: "md" }),
+    ).result.current;
+    const large = renderHook(() =>
+      useAnimatedNumberLayout({ ...parsed, size: "lg" }),
+    ).result.current;
+
+    expect(large.fontSize).toBe(80);
+    expect(large.itemHeight).toBe(75);
+    expect(large.totalContentWidth).toBeCloseTo(
+      medium.totalContentWidth * 1.25,
+    );
+  });
+
+  it("retains digit-count compression for long tablet amounts", () => {
+    const parsed = getCharactersArray("$123,456.78");
+    const { result } = renderHook(() =>
+      useAnimatedNumberLayout({ ...parsed, size: "lg" }),
+    );
+
+    expect(result.current.scale).toBe(0.85);
+    expect(result.current.totalContentWidth).toBeGreaterThan(0);
+  });
+});

--- a/dapps/pos-app/components/big-amount-input/hooks/useAnimatedNumberLayout.ts
+++ b/dapps/pos-app/components/big-amount-input/hooks/useAnimatedNumberLayout.ts
@@ -1,5 +1,5 @@
 import type { CharacterItem } from "../utils/getCharactersArray";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 const ITEM_HEIGHT = 60;
 const CURRENCY_SPACE = 6;
@@ -28,12 +28,15 @@ const CHARACTER_WIDTHS: Record<string, number> = {
 };
 const DEFAULT_WIDTH = 40;
 
-const getCharWidth = (char: string): number =>
-  CHARACTER_WIDTHS[char] ?? DEFAULT_WIDTH;
+const SIZE_SCALE = {
+  md: 1,
+  lg: 1.25,
+} as const;
 
 type UseAnimatedNumberLayoutParams = {
   characters: CharacterItem[];
   separators: (string | null)[];
+  size?: keyof typeof SIZE_SCALE;
 };
 
 function getScaleForLength(length: number): number {
@@ -54,6 +57,7 @@ export type CharacterLayoutInfo = {
 
 export type AnimatedNumberLayout = {
   itemHeight: number;
+  fontSize: number;
   scale: number;
   totalContentWidth: number;
   characterLayouts: CharacterLayoutInfo[];
@@ -63,7 +67,14 @@ export type AnimatedNumberLayout = {
 export const useAnimatedNumberLayout = ({
   characters,
   separators,
+  size = "md",
 }: UseAnimatedNumberLayoutParams): AnimatedNumberLayout => {
+  const sizeScale = SIZE_SCALE[size];
+  const getCharWidth = useCallback(
+    (char: string): number =>
+      (CHARACTER_WIDTHS[char] ?? DEFAULT_WIDTH) * sizeScale,
+    [sizeScale],
+  );
   const scale = useMemo(
     () => getScaleForLength(characters.length),
     [characters.length],
@@ -80,7 +91,7 @@ export const useAnimatedNumberLayout = ({
       const spacingWidth = visualWidth * SPACING_FACTOR;
 
       if (!isCurrency && index > 0) {
-        if (index === 1) pos += CURRENCY_SPACE;
+        if (index === 1) pos += CURRENCY_SPACE * sizeScale;
         const prevSep = separators[index - 1];
         if (prevSep) pos += getCharWidth(prevSep) * scale;
       }
@@ -90,7 +101,7 @@ export const useAnimatedNumberLayout = ({
     });
 
     return layouts;
-  }, [characters, separators, scale]);
+  }, [characters, separators, scale, sizeScale, getCharWidth]);
 
   const totalContentWidth = useMemo(() => {
     if (characterLayouts.length === 0) return 0;
@@ -100,12 +111,13 @@ export const useAnimatedNumberLayout = ({
 
   return useMemo(
     () => ({
-      itemHeight: ITEM_HEIGHT,
+      itemHeight: ITEM_HEIGHT * sizeScale,
+      fontSize: 64 * sizeScale,
       scale,
       totalContentWidth,
       characterLayouts,
       getCharWidth,
     }),
-    [scale, totalContentWidth, characterLayouts],
+    [scale, totalContentWidth, characterLayouts, sizeScale, getCharWidth],
   );
 };

--- a/dapps/pos-app/components/button.test.tsx
+++ b/dapps/pos-app/components/button.test.tsx
@@ -77,6 +77,29 @@ describe("Button", () => {
     expect(flattenedStyle.borderWidth).toBe(1);
   });
 
+  it("supports the large tablet size", () => {
+    const screen = render(
+      <Button
+        type="accent"
+        variant="primary"
+        size="lg"
+        testID="large-button"
+        onPress={() => {}}
+      >
+        Charge
+      </Button>,
+    );
+
+    const button = screen.getByTestId("large-button");
+    const label = screen.getByText("Charge");
+
+    expect(StyleSheet.flatten(button.props.style).height).toBe(64);
+    expect(StyleSheet.flatten(label.props.style)).toMatchObject({
+      fontSize: 22,
+      lineHeight: 24,
+    });
+  });
+
   it("supports the neutral tertiary variant and compact width", () => {
     const button = render(
       <Button

--- a/dapps/pos-app/components/button.tsx
+++ b/dapps/pos-app/components/button.tsx
@@ -12,7 +12,7 @@ interface ButtonBaseProps {
   onPress: () => void;
   disabled?: boolean;
   fullWidth?: boolean;
-  size?: "md" | "sm";
+  size?: "lg" | "md" | "sm";
   testID?: string;
   /** Overrides the accessible name (defaults to the button's text label). */
   accessibilityLabel?: string;
@@ -39,6 +39,7 @@ export function Button({
 }: ButtonProps) {
   const theme = useTheme();
   const isSmall = size === "sm";
+  const isLarge = size === "lg";
 
   const variantStyle =
     type === "accent"
@@ -72,17 +73,24 @@ export function Button({
       style={[
         styles.button,
         isSmall && styles.buttonSmall,
+        isLarge && styles.buttonLarge,
         fullWidth && styles.fullWidth,
         variantStyle,
         disabled && styles.disabled,
         style,
       ]}
     >
-      <View style={[styles.content, isSmall && styles.contentSmall]}>
+      <View
+        style={[
+          styles.content,
+          isSmall && styles.contentSmall,
+          isLarge && styles.contentLarge,
+        ]}
+      >
         <ThemedText
           color={textColor}
-          fontSize={isSmall ? 12 : 18}
-          lineHeight={isSmall ? 14 : 20}
+          fontSize={isSmall ? 12 : isLarge ? 22 : 18}
+          lineHeight={isSmall ? 14 : isLarge ? 24 : 20}
           style={styles.label}
         >
           {children}
@@ -105,6 +113,9 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     paddingHorizontal: Spacing["spacing-3"],
   },
+  buttonLarge: {
+    height: 64,
+  },
   content: {
     flexDirection: "row",
     alignItems: "center",
@@ -113,6 +124,9 @@ const styles = StyleSheet.create({
   },
   contentSmall: {
     gap: Spacing["spacing-1"],
+  },
+  contentLarge: {
+    gap: Spacing["spacing-3"],
   },
   label: {
     textAlign: "center",

--- a/dapps/pos-app/components/numeric-keyboard.test.tsx
+++ b/dapps/pos-app/components/numeric-keyboard.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { StyleSheet } from "react-native";
+
+import { Colors } from "@/constants/theme";
+
+import { NumericKeyboard } from "./numeric-keyboard";
+
+let mockTablet = false;
+const mockColors = Colors;
+
+jest.mock("react-native", () => ({
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    flatten: (style: unknown) => {
+      const flattened: Record<string, unknown> = {};
+      const applyStyle = (value: unknown) => {
+        if (Array.isArray(value)) {
+          value.forEach(applyStyle);
+        } else if (value && typeof value === "object") {
+          Object.assign(flattened, value);
+        }
+      };
+      applyStyle(style);
+      return flattened;
+    },
+  },
+  Platform: {
+    OS: "ios",
+    select: (options: Record<string, unknown>) =>
+      options.ios ?? options.default,
+  },
+  Text: "Text",
+  View: "View",
+}));
+
+jest.mock("@/hooks/use-is-tablet", () => ({
+  useIsTablet: () => mockTablet,
+}));
+
+jest.mock("@/hooks/use-theme-color", () => ({
+  useTheme: () => mockColors.light,
+  useThemeColor: (colorName: keyof typeof mockColors.light) =>
+    mockColors.light[colorName],
+}));
+
+jest.mock("expo-asset", () => ({
+  useAssets: () => [["backspace"]],
+}));
+
+jest.mock("expo-image", () => {
+  const mockReact = jest.requireActual("react");
+
+  return {
+    Image: (props: unknown) => mockReact.createElement("Image", props),
+  };
+});
+
+jest.mock("./pressable", () => {
+  const mockReact = jest.requireActual("react");
+
+  return {
+    Pressable: ({ children, ...props }: React.PropsWithChildren<any>) =>
+      mockReact.createElement("View", props, children),
+  };
+});
+
+describe("NumericKeyboard", () => {
+  beforeEach(() => {
+    mockTablet = false;
+  });
+
+  it("keeps the existing phone metrics", () => {
+    const screen = render(<NumericKeyboard onKeyPress={() => {}} />);
+
+    expect(
+      StyleSheet.flatten(screen.getByTestId("key-1").props.style),
+    ).toMatchObject({ height: 64 });
+    expect(StyleSheet.flatten(screen.getByText("1").props.style)).toMatchObject(
+      {
+        fontSize: 22,
+        lineHeight: 26,
+      },
+    );
+  });
+
+  it("uses larger keys, labels, and backspace icon on tablets", () => {
+    mockTablet = true;
+    const screen = render(<NumericKeyboard onKeyPress={() => {}} />);
+
+    expect(
+      StyleSheet.flatten(screen.getByTestId("key-1").props.style),
+    ).toMatchObject({ height: 96 });
+    expect(StyleSheet.flatten(screen.getByText("1").props.style)).toMatchObject(
+      {
+        fontSize: 28,
+        lineHeight: 32,
+      },
+    );
+
+    const backspaceIcon = screen
+      .getByLabelText("Backspace")
+      .findByType("Image");
+    expect(StyleSheet.flatten(backspaceIcon.props.style)).toMatchObject({
+      width: 28,
+      height: 28,
+    });
+  });
+
+  it("emits decimal and backspace input", () => {
+    const onKeyPress = jest.fn();
+    const screen = render(<NumericKeyboard onKeyPress={onKeyPress} />);
+
+    fireEvent.press(screen.getByTestId("key-decimal"));
+    fireEvent.press(screen.getByTestId("key-erase"));
+
+    expect(onKeyPress).toHaveBeenNthCalledWith(1, ".");
+    expect(onKeyPress).toHaveBeenNthCalledWith(2, "erase");
+  });
+});

--- a/dapps/pos-app/components/numeric-keyboard.tsx
+++ b/dapps/pos-app/components/numeric-keyboard.tsx
@@ -1,5 +1,6 @@
 import { BorderRadius, Spacing } from "@/constants/spacing";
 import { useTheme } from "@/hooks/use-theme-color";
+import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useAssets } from "expo-asset";
 import { Image } from "expo-image";
 import { memo } from "react";
@@ -14,6 +15,7 @@ export interface NumericKeyboardProps {
 
 function NumericKeyboardBase({ onKeyPress, style }: NumericKeyboardProps) {
   const Theme = useTheme();
+  const isTablet = useIsTablet();
   const [assets] = useAssets([require("@/assets/images/backspace.png")]);
   const keys = [
     ["1", "2", "3"],
@@ -27,9 +29,12 @@ function NumericKeyboardBase({ onKeyPress, style }: NumericKeyboardProps) {
   };
 
   return (
-    <View style={[styles.container, style]}>
+    <View style={[styles.container, isTablet && styles.containerTablet, style]}>
       {keys.map((row, rowIndex) => (
-        <View key={`row-${rowIndex}`} style={styles.row}>
+        <View
+          key={`row-${rowIndex}`}
+          style={[styles.row, isTablet && styles.rowTablet]}
+        >
           {row.map((key) => (
             <Pressable
               key={key}
@@ -39,6 +44,7 @@ function NumericKeyboardBase({ onKeyPress, style }: NumericKeyboardProps) {
               accessibilityLabel={key === "erase" ? "Backspace" : key}
               style={[
                 styles.key,
+                isTablet && styles.keyTablet,
                 { backgroundColor: Theme["foreground-primary-fix"] },
               ]}
             >
@@ -47,6 +53,7 @@ function NumericKeyboardBase({ onKeyPress, style }: NumericKeyboardProps) {
                   source={assets?.[0]}
                   style={[
                     styles.backspace,
+                    isTablet && styles.backspaceTablet,
                     {
                       tintColor: Theme["text-primary"],
                     },
@@ -57,7 +64,11 @@ function NumericKeyboardBase({ onKeyPress, style }: NumericKeyboardProps) {
                 />
               ) : (
                 <ThemedText
-                  style={[styles.keyText, { color: Theme["text-primary"] }]}
+                  style={[
+                    styles.keyText,
+                    isTablet && styles.keyTextTablet,
+                    { color: Theme["text-primary"] },
+                  ]}
                 >
                   {key}
                 </ThemedText>
@@ -77,10 +88,16 @@ const styles = StyleSheet.create({
     width: "100%",
     gap: Spacing["spacing-3"],
   },
+  containerTablet: {
+    gap: Spacing["spacing-5"],
+  },
   row: {
     flexDirection: "row",
     justifyContent: "space-around",
     gap: Spacing["spacing-3"],
+  },
+  rowTablet: {
+    gap: Spacing["spacing-5"],
   },
   key: {
     flex: 1,
@@ -89,12 +106,23 @@ const styles = StyleSheet.create({
     alignItems: "center",
     borderRadius: BorderRadius["4"],
   },
+  keyTablet: {
+    height: 96,
+  },
   keyText: {
     fontSize: 22,
     lineHeight: 26,
   },
+  keyTextTablet: {
+    fontSize: 28,
+    lineHeight: 32,
+  },
   backspace: {
     width: 22,
     height: 22,
+  },
+  backspaceTablet: {
+    width: 28,
+    height: 28,
   },
 });

--- a/dapps/pos-app/hooks/use-is-tablet.ts
+++ b/dapps/pos-app/hooks/use-is-tablet.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Platform } from "react-native";
 import { isTablet } from "react-native-device-info";
 
@@ -10,7 +11,11 @@ export function getIsTablet(
 /**
  * Returns true for native tablets while keeping every web viewport in the
  * existing phone-sized POS presentation.
+ *
+ * The classification is a stable device constant, so it is memoised to make
+ * the "this never changes" contract explicit and to query device info only
+ * once per component mount.
  */
 export function useIsTablet(): boolean {
-  return getIsTablet();
+  return useMemo(() => getIsTablet(), []);
 }

--- a/dapps/pos-app/hooks/use-is-tablet.ts
+++ b/dapps/pos-app/hooks/use-is-tablet.ts
@@ -1,0 +1,16 @@
+import { Platform } from "react-native";
+import { isTablet } from "react-native-device-info";
+
+export function getIsTablet(
+  platform: typeof Platform.OS = Platform.OS,
+): boolean {
+  return platform !== "web" && isTablet();
+}
+
+/**
+ * Returns true for native tablets while keeping every web viewport in the
+ * existing phone-sized POS presentation.
+ */
+export function useIsTablet(): boolean {
+  return getIsTablet();
+}

--- a/dapps/pos-app/jest.setup.js
+++ b/dapps/pos-app/jest.setup.js
@@ -111,6 +111,7 @@ jest.mock("expo-local-authentication", () => {
 jest.mock("react-native-device-info", () => {
   return {
     getUniqueId: jest.fn(() => Promise.resolve("mock-device-id-12345")),
+    isTablet: jest.fn(() => false),
   };
 });
 


### PR DESCRIPTION
## Summary

- add native tablet detection while preserving the phone-sized web frame
- rebalance home actions with square secondary cards, larger spacing, and tablet typography
- enlarge the amount keypad, animated amount, QR payment flow, and loading state
- scale success and failure icons, copy, and CTAs for tablet readability
- bump the Android version code to 31

## Screenshot
<img height="800" alt="Screenshot 2026-08-24 at 3 50 59 PM" src="https://github.com/user-attachments/assets/2d765f81-e1e1-4d16-810a-c42e36ae479a" />

<img height="800" alt="Screenshot 2026-08-24 at 3 51 11 PM" src="https://github.com/user-attachments/assets/07a6d853-7c5a-4a93-b1a3-6bb96e48e27a" />

<img height="800" alt="Screenshot 2026-08-24 at 3 51 15 PM" src="https://github.com/user-attachments/assets/cadcccc3-a6c9-4f60-a951-bbccf2e1b00a" />

<img height="800" alt="Screenshot 2026-08-24 at 3 51 25 PM" src="https://github.com/user-attachments/assets/91b02a71-2682-4217-a4fe-2c6919393a3b" />

<img height="800" alt="Screenshot 2026-08-24 at 3 51 31 PM" src="https://github.com/user-attachments/assets/a30be95c-dcc6-4972-a96a-56966c007e2a" />



## Known repository baselines

- npm run format:check flags the pre-existing assets/lottie/Success.json formatting
- npx tsc --noEmit reports pre-existing missing Jest global types across test files; changed application source reports no TypeScript errors
