### PR TITLE
fix(ci): disable Foundry toolchain cache in balance check

### DIFF
--- a/.github/workflows/e2e-balance-check.yml
+++ b/.github/workflows/e2e-balance-check.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
+        with:
+          # Skip the action's binary cache: a poisoned cache entry restored a
+          # corrupt `foundryup` ("cannot execute binary file"). We only need
+          # `cast`, so a fresh download each run is cheap and reliable.
+          cache: false
 
       - name: Check USDC balance on Base
         id: usdc_balance


### PR DESCRIPTION
## Problem

The **E2E Wallet Balance Check** job was failing on the first step, before any `cast` call ran:

```
Running: foundryup
##[error]/home/runner/.foundry/bin/foundryup: cannot execute binary file
##[error]Error: Command failed: bash "/home/runner/.foundry/bin/foundryup"
```

`foundry-rs/foundry-toolchain` defaults to `cache: true`. A poisoned Actions cache entry (under the shared `check-balance-` key) restored a corrupt `foundryup`, so `bash foundryup` hit a binary blob and errored. Re-running just restores the same bad cache — it keeps failing.

Failing run: https://github.com/reown-com/react-native-examples/actions/runs/32886394499/job/97936313536

## Fix

Set `cache: false` on the Foundry install step. The job only needs `cast`, so a fresh download each run is cheap and sidesteps the poisoned-cache trap entirely — nothing is restored or saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)