### PR TITLE
fix(ci): update Foundry toolchain action

### DIFF
--- a/.github/workflows/e2e-balance-check.yml
+++ b/.github/workflows/e2e-balance-check.yml
@@ -27,11 +27,10 @@ jobs:
       SLACK_FAUCETBOT_WEBHOOK_URL: ${{ secrets.SLACK_FAUCETBOT_WEBHOOK_URL }}
     steps:
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          # Skip the action's binary cache: a poisoned cache entry restored a
-          # corrupt `foundryup` ("cannot execute binary file"). We only need
-          # `cast`, so a fresh download each run is cheap and reliable.
+          # This balance-only job does not run fork tests, so Foundry's RPC/fork
+          # cache is unnecessary. We only need a fresh `cast` installation.
           cache: false
 
       - name: Check USDC balance on Base

--- a/.github/workflows/e2e-balance-check.yml
+++ b/.github/workflows/e2e-balance-check.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          # This balance-only job does not run fork tests, so Foundry's RPC/fork
-          # cache is unnecessary. We only need a fresh `cast` installation.
           cache: false
 
       - name: Check USDC balance on Base


### PR DESCRIPTION
## Summary

- update foundry-rs/foundry-toolchain from v1.7.0 to the immutable v1.9.1 SHA
- keep stable Foundry resolution and disable the unnecessary RPC/fork cache
- avoid invoking the new native foundryup binary through Bash

## Validation

- YAML syntax and git diff checks pass
- targeted E2E Wallet Balance Check succeeded on Ubuntu
- cast 1.7.1 installed and all four balance checks completed

Validation run: https://github.com/reown-com/react-native-examples/actions/runs/32976263608