### PR TITLE
fix(pos-app): disable Sentry structured logs

### DIFF
--- a/dapps/pos-app/app/_layout.tsx
+++ b/dapps/pos-app/app/_layout.tsx
@@ -47,9 +47,7 @@ Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
   sendDefaultPii: false,
 
-  // Structured logging adds serialization + network overhead in production and
-  // duplicates the in-app logs store, so keep it to development only.
-  enableLogs: __DEV__,
+  enableLogs: false,
 
   // Configure Session Replay
   replaysSessionSampleRate: 0,


### PR DESCRIPTION
Turns off Sentry structured logging in the pos-app sample by setting `enableLogs: false` in `dapps/pos-app/app/_layout.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)