### PR TITLE
fix(pos-app): cancel payment when leaving scan screen via back

### DIFF
--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -35,7 +35,7 @@
         "android.permission.BLUETOOTH_ADVERTISE",
         "android.permission.USB_PERMISSION"
       ],
-      "versionCode": 2
+      "versionCode": 3
     },
     "web": {
       "output": "static",

--- a/dapps/pos-app/app/scan.tsx
+++ b/dapps/pos-app/app/scan.tsx
@@ -56,6 +56,7 @@ export default function ScanScreen() {
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const hasNavigatedRef = useRef(false);
   const hasCancelledRef = useRef(false);
+  const hasLeftRef = useRef(false);
   const navigation = useNavigation();
 
   const deviceId = useSettingsStore((state) => state.deviceId);
@@ -157,6 +158,24 @@ export default function ScanScreen() {
 
         const data = await startPayment(paymentRequest);
 
+        // The user can back out while this create call is in flight, before
+        // `paymentId` state exists for the `beforeRemove` listener to cancel.
+        // Cancel the freshly opened payment here instead of rendering a QR for
+        // a screen that's already gone.
+        if (hasLeftRef.current) {
+          hasCancelledRef.current = true;
+          cancelPayment(data.paymentId).catch((error) => {
+            addLog(
+              "error",
+              "Failed to cancel payment",
+              "scan",
+              "cancelPayment",
+              { paymentId: data.paymentId, error },
+            );
+          });
+          return;
+        }
+
         addLog("info", "Payment started", "scan", "initiatePayment", {
           paymentId: data.paymentId,
           gatewayUrl: data.gatewayUrl,
@@ -165,6 +184,8 @@ export default function ScanScreen() {
         setPaymentId(data.paymentId);
         setExpiresAt(data.expiresAt);
       } catch (error: any) {
+        // Nothing to route to if the user already left mid-request.
+        if (hasLeftRef.current) return;
         addLog(
           "error",
           (error as Error).message || "Unknown error",
@@ -212,6 +233,9 @@ export default function ScanScreen() {
   // resolved yet — cancel then too.
   const cancelPendingPayment = useCallback(() => {
     if (hasNavigatedRef.current || hasCancelledRef.current) return;
+    // Record the leave so an in-flight `startPayment` cancels the payment it
+    // creates instead of leaking it (see `initiatePayment`).
+    hasLeftRef.current = true;
     const status = paymentStatusData?.status;
     if (paymentId && (status === undefined || status === "requires_action")) {
       hasCancelledRef.current = true;

--- a/dapps/pos-app/app/scan.tsx
+++ b/dapps/pos-app/app/scan.tsx
@@ -4,6 +4,7 @@ import { ThemedText } from "@/components/themed-text";
 import { WalletConnectLoading } from "@/components/walletconnect-loading";
 import { Spacing } from "@/constants/spacing";
 import { useCountdown } from "@/hooks/use-countdown";
+import { useDisableBackButton } from "@/hooks/use-disable-back-button";
 import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useNfcPayment } from "@/hooks/use-nfc-payment";
 import { useTheme } from "@/hooks/use-theme-color";
@@ -29,6 +30,7 @@ import {
   Stack,
   UnknownOutputParams,
   useLocalSearchParams,
+  useNavigation,
 } from "expo-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { AccessibilityInfo, StyleSheet, View } from "react-native";
@@ -53,6 +55,8 @@ export default function ScanScreen() {
   const [paymentId, setPaymentId] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const hasNavigatedRef = useRef(false);
+  const hasCancelledRef = useRef(false);
+  const navigation = useNavigation();
 
   const deviceId = useSettingsStore((state) => state.deviceId);
   const merchantId = useSettingsStore((state) => state.merchantId);
@@ -116,18 +120,7 @@ export default function ScanScreen() {
   );
 
   const handleOnCancelPress = () => {
-    // Before the first status poll resolves, `paymentStatusData` is undefined
-    // but the payment is already open at the gateway — cancel it then too.
-    const status = paymentStatusData?.status;
-    if (paymentId && (status === undefined || status === "requires_action")) {
-      cancelPayment(paymentId).catch((error) => {
-        addLog("error", "Failed to cancel payment", "scan", "cancelPayment", {
-          paymentId,
-          error,
-        });
-        showErrorToast("We couldn't cancel this payment. Try again.");
-      });
-    }
+    // The `beforeRemove` listener below cancels the payment on leave.
     resetNavigation("/amount");
   };
 
@@ -213,6 +206,32 @@ export default function ScanScreen() {
     },
   });
 
+  // Cancel the open payment when the user leaves the scan screen. `hasNavigatedRef`
+  // is set before we route to success/failure, so those transitions don't cancel.
+  // A still-undefined status means the payment is open but the first poll hasn't
+  // resolved yet — cancel then too.
+  const cancelPendingPayment = useCallback(() => {
+    if (hasNavigatedRef.current || hasCancelledRef.current) return;
+    const status = paymentStatusData?.status;
+    if (paymentId && (status === undefined || status === "requires_action")) {
+      hasCancelledRef.current = true;
+      cancelPayment(paymentId).catch((error) => {
+        addLog("error", "Failed to cancel payment", "scan", "cancelPayment", {
+          paymentId,
+          error,
+        });
+        showErrorToast("We couldn't cancel this payment. Try again.");
+      });
+    }
+  }, [paymentId, paymentStatusData?.status, addLog]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener("beforeRemove", () => {
+      cancelPendingPayment();
+    });
+    return unsubscribe;
+  }, [navigation, cancelPendingPayment]);
+
   const { remainingSeconds, isActive: isCountdownActive } = useCountdown({
     expiresAt,
     onExpired: () => onFailure("expired"),
@@ -258,6 +277,10 @@ export default function ScanScreen() {
   // the react-hooks lint rules.)
   const backHidden =
     !!paymentStatusData && paymentStatusData.status !== "requires_action";
+
+  // Block the Android hardware back button whenever the header back and gesture
+  // are hidden, so it can't pop the screen mid-confirmation.
+  useDisableBackButton(backHidden);
 
   return (
     <View style={styles.container}>

--- a/dapps/pos-app/app/scan.tsx
+++ b/dapps/pos-app/app/scan.tsx
@@ -220,17 +220,27 @@ export default function ScanScreen() {
           paymentId,
           error,
         });
-        showErrorToast("We couldn't cancel this payment. Try again.");
+        // No "try again" — by the time this rejects the user has already left
+        // the scan screen and has no way to retry from here.
+        showErrorToast("We couldn't cancel this payment.");
       });
     }
   }, [paymentId, paymentStatusData?.status, addLog]);
 
+  // Hold the latest callback in a ref so the `beforeRemove` listener stays
+  // registered once for the screen's lifetime instead of being torn down and
+  // re-added on every status poll (which changes `cancelPendingPayment`).
+  const cancelPendingPaymentRef = useRef(cancelPendingPayment);
+  useEffect(() => {
+    cancelPendingPaymentRef.current = cancelPendingPayment;
+  }, [cancelPendingPayment]);
+
   useEffect(() => {
     const unsubscribe = navigation.addListener("beforeRemove", () => {
-      cancelPendingPayment();
+      cancelPendingPaymentRef.current();
     });
     return unsubscribe;
-  }, [navigation, cancelPendingPayment]);
+  }, [navigation]);
 
   const { remainingSeconds, isActive: isCountdownActive } = useCountdown({
     expiresAt,

--- a/dapps/pos-app/hooks/use-disable-back-button.ts
+++ b/dapps/pos-app/hooks/use-disable-back-button.ts
@@ -4,6 +4,8 @@ import { BackHandler, Platform } from "react-native";
 /**
  * Custom hook to disable the Android hardware back button
  *
+ * @param enabled - Whether the block is active (defaults to `true`).
+ *
  * @example
  *
  * const MyComponent = () => {
@@ -11,9 +13,9 @@ import { BackHandler, Platform } from "react-native";
  *   // ... rest of component
  * };
  *  */
-export function useDisableBackButton() {
+export function useDisableBackButton(enabled = true) {
   useEffect(() => {
-    if (Platform.OS !== "android") {
+    if (Platform.OS !== "android" || !enabled) {
       return;
     }
 
@@ -26,5 +28,5 @@ export function useDisableBackButton() {
     );
 
     return () => backHandler.remove();
-  }, []);
+  }, [enabled]);
 }


### PR DESCRIPTION
## Summary

Pressing back on the POS scan screen previously left the payment open at the gateway — only the on-screen **Cancel** button cancelled it. This wires the cancel logic into a single `beforeRemove` navigation listener so the **hardware back button**, **header back arrow**, and **swipe-back gesture** all cancel the payment uniformly.

Success and failure navigations are guarded by `hasNavigatedRef` (set before routing), so reaching a terminal state never triggers a cancel. The Android hardware back button is now also blocked while the header back and gesture are hidden (e.g. during `processing`). Also bumps Android `versionCode` 2 → 3.

## Flow

```mermaid
flowchart TD
    A[User on scan screen] --> B{How do they leave?}
    B -->|Hardware back / header back / swipe| C[beforeRemove listener]
    B -->|Cancel button| D[resetNavigation] --> C
    B -->|Payment succeeds/fails| E[hasNavigatedRef = true] --> F[Navigate to result] --> C
    C --> G{hasNavigatedRef or already cancelled?}
    G -->|Yes| H[Skip - no cancel]
    G -->|No| I{status undefined or requires_action?}
    I -->|Yes| J[cancelPayment]
    I -->|No| H
```