### PR TITLE
ci(walletkit-maestro): pin Android emulator DNS to fix flaky no-internet

### DIFF
--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -234,9 +234,6 @@ runs:
       if: inputs.platform == 'ios'
       shell: bash
       working-directory: ${{ steps.paths.outputs.wallet_root }}
-      # ios/ is generated (Continuous Native Generation). APP_VARIANT=internal so
-      # app.config.js sets the .internal bundle id; pods are installed by the
-      # fastlane lane (honoring the Pods cache below), hence --no-install.
       run: APP_VARIANT=internal npx expo prebuild --platform ios --no-install
 
     - name: Set Xcode paths
@@ -259,8 +256,6 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.paths.outputs.wallet_root }}/ios/Pods
-        # No restore-keys: a prefix match restores a stale Pods/ on a Podfile.lock
-        # bump (hermes-engine podspec mismatch) and breaks `pod install` (#515).
         # Exact Podfile.lock match only; otherwise start clean and reinstall.
         key: ${{ runner.os }}-pods-${{ github.ref_name }}-${{ hashFiles(format('{0}/ios/Podfile.lock', steps.paths.outputs.wallet_root)) }}
 
@@ -667,7 +662,7 @@ runs:
         heap-size: 576M
         emulator-boot-timeout: 900
         force-avd-creation: false
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-load
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-load -dns-server 8.8.8.8,8.8.4.4
         disable-animations: true
         script: |
           adb install "$APK_PATH"

--- a/.github/actions/walletkit-build-and-maestro/action.yml
+++ b/.github/actions/walletkit-build-and-maestro/action.yml
@@ -257,6 +257,8 @@ runs:
       with:
         path: ${{ steps.paths.outputs.wallet_root }}/ios/Pods
         # Exact Podfile.lock match only; otherwise start clean and reinstall.
+        # No restore-keys: prefix match restores stale Pods on a Podfile.lock
+        # bump (hermes-engine mismatch) and breaks `pod install` (see #515).
         key: ${{ runner.os }}-pods-${{ github.ref_name }}-${{ hashFiles(format('{0}/ios/Podfile.lock', steps.paths.outputs.wallet_root)) }}
 
     - name: Build for Simulator


### PR DESCRIPTION
## What

Pin `-dns-server 8.8.8.8,8.8.4.4` in the Android emulator's `emulator-options` in the shared `walletkit-build-and-maestro` composite action. Also removes a few stale inline comments in the same file.

## Why

A scheduled E2E run ([run 33303451561](https://github.com/reown-com/react-native-examples/actions/runs/33303451561/job/99235721614)) failed on the **Android leg only** — iOS was cancelled by the failure and web passed. Every pay flow failed at its first network call, and the logcat shows the same error on every launch for the full ~23-minute run, across both retry attempts:

```
E ReactNativeJS: [PayError: v1=No internet connection. Please check your connection and try again]
                 'WalletConnectPay getPaymentOptions error'
```

The emulator had **no outbound network for the entire run** — a uniform 100% failure, not flake. iOS/web pass because they use the runner's network directly; the Android emulator is the only leg behind QEMU's virtualized NAT + host-DNS forwarding, which intermittently comes up broken on CI runners.

Pinning public DNS resolvers sidesteps the flaky forwarded resolver, which is the usual root cause of emulator "no internet" on `reactivecircus/android-emulator-runner`.

## Scope

- DNS change only for now. A fast connectivity **preflight** (fail in ~30s with an "infra, not a regression" message instead of burning ~23 min) is a good follow-up but intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)