### PR TITLE
fix(pos): improve payment error feedback

### DIFF
--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -35,7 +35,7 @@
         "android.permission.BLUETOOTH_ADVERTISE",
         "android.permission.USB_PERMISSION"
       ],
-      "versionCode": 3
+      "versionCode": 4
     },
     "web": {
       "output": "static",

--- a/dapps/pos-app/app/activity.tsx
+++ b/dapps/pos-app/app/activity.tsx
@@ -106,15 +106,17 @@ export default function ActivityScreen() {
     dateRangeFilter,
   });
 
-  // Show error toast when fetch fails
+  const isEmpty = !transactions || transactions.length === 0;
+
+  // An initial failure replaces the list with an error state. If data is
+  // already visible, retain it and give the merchant lightweight feedback.
   useEffect(() => {
-    if (isError && error) {
+    if (isError && error && !isEmpty) {
       showErrorToast(
-        error.message ||
-          "We couldn't load your transactions. Pull to refresh, or try again in a moment.",
+        "We couldn't refresh payments. Check your internet connection and try again.",
       );
     }
-  }, [isError, error]);
+  }, [isError, error, isEmpty]);
 
   const closeSheet = useCallback(() => {
     setActiveSheet(null);
@@ -145,8 +147,6 @@ export default function ActivityScreen() {
     setModalVisible(false);
     setSelectedPayment(null);
   }, []);
-
-  const isEmpty = !transactions || transactions.length === 0;
 
   const filtersActive =
     transactionFilter !== "all" || dateRangeFilter !== "all_time";
@@ -181,6 +181,16 @@ export default function ActivityScreen() {
       );
     }
 
+    if (isError) {
+      return (
+        <EmptyState
+          title="We couldn't load payments"
+          subtitle="Check your internet connection and try again."
+          cta={{ label: "Try again", onPress: refetch }}
+        />
+      );
+    }
+
     if (filtersActive) {
       return (
         <EmptyState
@@ -201,7 +211,7 @@ export default function ActivityScreen() {
         }}
       />
     );
-  }, [isLoading, theme, filtersActive, handleClearFilters]);
+  }, [isLoading, isError, theme, filtersActive, handleClearFilters, refetch]);
 
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/dapps/pos-app/app/activity.tsx
+++ b/dapps/pos-app/app/activity.tsx
@@ -93,6 +93,7 @@ export default function ActivityScreen() {
 
   const {
     transactions,
+    data: transactionData,
     isLoading,
     isError,
     error,
@@ -107,16 +108,18 @@ export default function ActivityScreen() {
   });
 
   const isEmpty = !transactions || transactions.length === 0;
+  const hasLoadedData = transactionData !== undefined;
+  const errorMessage = error?.message;
 
   // An initial failure replaces the list with an error state. If data is
   // already visible, retain it and give the merchant lightweight feedback.
   useEffect(() => {
-    if (isError && error && !isEmpty) {
+    if (isError && errorMessage && hasLoadedData) {
       showErrorToast(
         "We couldn't refresh payments. Check your internet connection and try again.",
       );
     }
-  }, [isError, error, isEmpty]);
+  }, [isError, errorMessage, hasLoadedData]);
 
   const closeSheet = useCallback(() => {
     setActiveSheet(null);
@@ -181,12 +184,12 @@ export default function ActivityScreen() {
       );
     }
 
-    if (isError) {
+    if (isError && !hasLoadedData) {
       return (
         <EmptyState
           title="We couldn't load payments"
           subtitle="Check your internet connection and try again."
-          cta={{ label: "Try again", onPress: refetch }}
+          cta={{ label: "Try again", onPress: () => void refetch() }}
         />
       );
     }
@@ -211,7 +214,15 @@ export default function ActivityScreen() {
         }}
       />
     );
-  }, [isLoading, isError, theme, filtersActive, handleClearFilters, refetch]);
+  }, [
+    isLoading,
+    isError,
+    hasLoadedData,
+    theme,
+    filtersActive,
+    handleClearFilters,
+    refetch,
+  ]);
 
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/dapps/pos-app/app/activity.tsx
+++ b/dapps/pos-app/app/activity.tsx
@@ -110,6 +110,7 @@ export default function ActivityScreen() {
   const isEmpty = !transactions || transactions.length === 0;
   const hasLoadedData = transactionData !== undefined;
   const errorMessage = error?.message;
+  const isInitialLoadError = isError && !hasLoadedData;
 
   // An initial failure replaces the list with an error state. If data is
   // already visible, retain it and give the merchant lightweight feedback.
@@ -184,7 +185,7 @@ export default function ActivityScreen() {
       );
     }
 
-    if (isError && !hasLoadedData) {
+    if (isInitialLoadError) {
       return (
         <EmptyState
           title="We couldn't load payments"
@@ -216,8 +217,7 @@ export default function ActivityScreen() {
     );
   }, [
     isLoading,
-    isError,
-    hasLoadedData,
+    isInitialLoadError,
     theme,
     filtersActive,
     handleClearFilters,
@@ -242,21 +242,28 @@ export default function ActivityScreen() {
 
   return (
     <View style={styles.container}>
-      <FilterButtons
-        buttons={[
-          {
-            label: STATUS_LABELS[transactionFilter],
-            onPress: () => setActiveSheet("status"),
-          },
-          {
-            label: DATE_RANGE_LABELS[dateRangeFilter],
-            onPress: () => setActiveSheet("dateRange"),
-          },
-        ]}
-      />
-      <View
-        style={[styles.divider, { backgroundColor: theme["border-primary"] }]}
-      />
+      {!isInitialLoadError && (
+        <>
+          <FilterButtons
+            buttons={[
+              {
+                label: STATUS_LABELS[transactionFilter],
+                onPress: () => setActiveSheet("status"),
+              },
+              {
+                label: DATE_RANGE_LABELS[dateRangeFilter],
+                onPress: () => setActiveSheet("dateRange"),
+              },
+            ]}
+          />
+          <View
+            style={[
+              styles.divider,
+              { backgroundColor: theme["border-primary"] },
+            ]}
+          />
+        </>
+      )}
       <FlatList
         data={transactions}
         renderItem={renderItem}

--- a/dapps/pos-app/app/settings.tsx
+++ b/dapps/pos-app/app/settings.tsx
@@ -201,8 +201,7 @@ export default function SettingsScreen() {
           { error },
         );
         showErrorToast(
-          error ||
-            "We couldn't connect to the printer. Check that it's on and paired in your device's Bluetooth settings.",
+          "We couldn't connect to the printer. Check that it's on and paired in your device's Bluetooth settings.",
         );
         return;
       }

--- a/dapps/pos-app/hooks/use-merchant-flow.ts
+++ b/dapps/pos-app/hooks/use-merchant-flow.ts
@@ -224,7 +224,7 @@ export function useMerchantFlow({
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Failed to save";
-      showErrorToast(errorMessage);
+      showErrorToast("We couldn't save this setting. Try again.");
       addLog("error", errorMessage, "settings", "completeSave");
     }
   }, [


### PR DESCRIPTION
## Summary
- show a retryable Activity error state when the initial payment load fails
- keep loaded payments visible and use a friendly toast for refresh failures
- prevent technical settings and printer errors from reaching merchants
- bump Android versionCode to 4

## Validation
- `git diff --check`
- Not run: app dependencies are not installed in this workspace (`jest`, `expo`, `prettier`, and TypeScript are unavailable).