### PR TITLE
fix(pos): isolate iframe sessions

### DIFF
--- a/dapps/pos-app/__tests__/hooks/use-pos-bridge.test.ts
+++ b/dapps/pos-app/__tests__/hooks/use-pos-bridge.test.ts
@@ -19,8 +19,8 @@ const parentWindow = { postMessage: parentPostMessage } as unknown as Window;
 const otherWindow = { postMessage: jest.fn() } as unknown as Window;
 const parentOrigin = "https://dashboard.example.com";
 
-function setWindowLocation(search = "") {
-  (global as any).window = {
+function setWindowLocation(search = "", isIframe = true) {
+  const frameWindow = {
     location: { search, href: `http://localhost${search}` },
     addEventListener: (type: string, handler: MessageHandler) => {
       if (type === "message") messageListeners.push(handler);
@@ -29,8 +29,13 @@ function setWindowLocation(search = "") {
       const index = messageListeners.indexOf(handler);
       if (type === "message" && index >= 0) messageListeners.splice(index, 1);
     },
-    parent: parentWindow,
+    postMessage: jest.fn(),
+    parent: isIframe ? parentWindow : undefined,
   };
+  (frameWindow as any).parent = isIframe ? parentWindow : frameWindow;
+  (frameWindow as any).self = frameWindow;
+  (frameWindow as any).top = isIframe ? parentWindow : frameWindow;
+  (global as any).window = frameWindow;
 }
 
 function dispatchMessage(
@@ -59,22 +64,30 @@ afterEach(() => {
 });
 
 describe("usePosBridge", () => {
-  it("clears an embedded stale key and announces bridge readiness", async () => {
+  it("preserves standalone credentials and announces bridge readiness", async () => {
     await useSettingsStore.getState().setCustomerApiKey("stale-key");
+    useSettingsStore.getState().setMerchantId("merchant-standalone");
     useSettingsStore.setState({ _hasHydrated: true });
 
     renderHook(() => usePosBridge());
     await act(() => waitForAsync());
 
-    expect(useSettingsStore.getState().isCustomerApiKeySet).toBe(false);
+    expect(useSettingsStore.getState()).toMatchObject({
+      merchantId: "merchant-standalone",
+      isCustomerApiKeySet: true,
+    });
+    await expect(useSettingsStore.getState().getCustomerApiKey()).resolves.toBe(
+      "stale-key",
+    );
     expect(parentPostMessage).toHaveBeenCalledWith(
       { type: "pos-ready", protocolVersion: 1 },
       "*",
     );
   });
 
-  it("configures the locked bridge and stores only the non-secret merchant ID", async () => {
+  it("configures the locked bridge without changing standalone credentials", async () => {
     await useSettingsStore.getState().setCustomerApiKey("stale-key");
+    useSettingsStore.getState().setMerchantId("merchant-standalone");
     useSettingsStore.setState({ _hasHydrated: true });
     renderHook(() => usePosBridge());
     await act(() => waitForAsync());
@@ -89,40 +102,12 @@ describe("usePosBridge", () => {
     });
 
     expect(useSettingsStore.getState()).toMatchObject({
-      merchantId: "merchant-bridge",
-      isCustomerApiKeySet: false,
+      merchantId: "merchant-standalone",
+      isCustomerApiKeySet: true,
     });
     expect(usePosBridgeStore.getState()).toMatchObject({
       isConfigured: true,
       merchantId: "merchant-bridge",
-    });
-  });
-
-  it("keeps the bridge merchant ID when clearing an old local key fails", async () => {
-    const originalClearCustomerApiKey =
-      useSettingsStore.getState().clearCustomerApiKey;
-    useSettingsStore.setState({
-      clearCustomerApiKey: async () => {
-        throw new Error("secure storage unavailable");
-      },
-    });
-    useSettingsStore.setState({ _hasHydrated: true });
-    renderHook(() => usePosBridge());
-    await act(() => waitForAsync());
-
-    await act(async () => {
-      dispatchMessage({
-        type: "pos-bridge-config",
-        protocolVersion: 1,
-        merchantId: "merchant-bridge",
-      });
-      await waitForAsync();
-    });
-
-    expect(useSettingsStore.getState().merchantId).toBe("merchant-bridge");
-    expect(usePosBridgeStore.getState().isConfigured).toBe(true);
-    useSettingsStore.setState({
-      clearCustomerApiKey: originalClearCustomerApiKey,
     });
   });
 
@@ -168,6 +153,27 @@ describe("usePosBridge", () => {
       await waitForAsync();
     });
     expect(usePosBridgeStore.getState().merchantId).toBe("merchant-bridge");
+  });
+
+  it("rejects bridge configuration from a standalone window", async () => {
+    setWindowLocation("", false);
+    useSettingsStore.setState({ _hasHydrated: true });
+    renderHook(() => usePosBridge());
+    await act(() => waitForAsync());
+
+    await act(async () => {
+      dispatchMessage(
+        {
+          type: "pos-bridge-config",
+          protocolVersion: 1,
+          merchantId: "merchant-bridge",
+        },
+        (global as any).window,
+      );
+      await waitForAsync();
+    });
+
+    expect(usePosBridgeStore.getState().isConfigured).toBe(false);
   });
 
   it("ignores legacy URL and postMessage credentials", async () => {

--- a/dapps/pos-app/__tests__/services/web-bridge-services.test.ts
+++ b/dapps/pos-app/__tests__/services/web-bridge-services.test.ts
@@ -10,11 +10,22 @@ import {
 } from "@/services/payment.web";
 import { getTransactions } from "@/services/transactions.web";
 import { useSettingsStore } from "@/store/useSettingsStore";
+import { Platform } from "react-native";
 import { clearTestMerchant, setupTestMerchant } from "../utils/store-helpers";
 
 const parentPostMessage = jest.fn();
 const parentWindow = { postMessage: parentPostMessage } as unknown as Window;
 const parentOrigin = "https://dashboard.example.com";
+let originalWindow: Window & typeof globalThis;
+let originalPlatform: string;
+
+function setEmbeddedWindow() {
+  (global as any).window = {
+    self: {},
+    top: {},
+    parent: parentWindow,
+  };
+}
 
 function respondWithSuccess(data: unknown) {
   const message = parentPostMessage.mock.calls[
@@ -36,6 +47,9 @@ function respondWithSuccess(data: unknown) {
 
 describe("web services with the POS bridge", () => {
   beforeEach(() => {
+    originalWindow = global.window;
+    originalPlatform = Platform.OS;
+    (Platform as any).OS = "web";
     resetBridge();
     parentPostMessage.mockClear();
     jest.clearAllMocks();
@@ -47,11 +61,14 @@ describe("web services with the POS bridge", () => {
   });
 
   afterEach(async () => {
+    (global as any).window = originalWindow;
+    (Platform as any).OS = originalPlatform;
     resetBridge();
     await clearTestMerchant();
   });
 
   it("uses the four bridge operations without reading the local key or fetching proxies", async () => {
+    setEmbeddedWindow();
     const getCustomerApiKey = useSettingsStore.getState()
       .getCustomerApiKey as jest.Mock;
     configureBridge(parentWindow, parentOrigin, "merchant-bridge");
@@ -144,5 +161,30 @@ describe("web services with the POS bridge", () => {
         }),
       }),
     );
+  });
+
+  it("does not fall back to standalone credentials while an iframe awaits bridge configuration", async () => {
+    setEmbeddedWindow();
+    const getCustomerApiKey = useSettingsStore.getState()
+      .getCustomerApiKey as jest.Mock;
+
+    await expect(
+      startPayment({
+        referenceId: "reference-iframe",
+        amount: { value: "100", unit: "cents" },
+      }),
+    ).rejects.toEqual({ message: "POS bridge is not configured" });
+    await expect(getPaymentStatus("pay-iframe")).rejects.toEqual({
+      message: "POS bridge is not configured",
+    });
+    await expect(cancelPayment("pay-iframe")).rejects.toEqual({
+      message: "POS bridge is not configured",
+    });
+    await expect(getTransactions()).rejects.toEqual({
+      message: "POS bridge is not configured",
+    });
+
+    expect(getCustomerApiKey).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/dapps/pos-app/__tests__/store/useLogsStore.test.ts
+++ b/dapps/pos-app/__tests__/store/useLogsStore.test.ts
@@ -1,4 +1,6 @@
 import { useLogsStore } from "@/store/useLogsStore";
+import { storage } from "@/utils/storage";
+import { Platform } from "react-native";
 import { resetLogsStore } from "../utils/store-helpers";
 
 describe("useLogsStore", () => {
@@ -227,6 +229,29 @@ describe("useLogsStore", () => {
 
       // Hydration state should be preserved
       expect(useLogsStore.getState()._hasHydrated).toBe(true);
+    });
+
+    it("keeps iframe logs out of shared storage", async () => {
+      const originalWindow = global.window;
+      const originalPlatform = Platform.OS;
+      const getItem = jest.spyOn(storage, "getItem");
+      const setItem = jest.spyOn(storage, "setItem");
+      (Platform as any).OS = "web";
+      (global as any).window = { self: {}, top: {} };
+
+      try {
+        await useLogsStore.persist.rehydrate();
+        useLogsStore.getState().addLog("info", "Iframe log");
+
+        expect(useLogsStore.getState().logs).toHaveLength(1);
+        expect(getItem).not.toHaveBeenCalled();
+        expect(setItem).not.toHaveBeenCalled();
+      } finally {
+        (global as any).window = originalWindow;
+        (Platform as any).OS = originalPlatform;
+        getItem.mockRestore();
+        setItem.mockRestore();
+      }
     });
   });
 });

--- a/dapps/pos-app/__tests__/utils/is-running-in-iframe.test.ts
+++ b/dapps/pos-app/__tests__/utils/is-running-in-iframe.test.ts
@@ -1,0 +1,26 @@
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
+import { Platform } from "react-native";
+
+describe("isRunningInIframe", () => {
+  const originalWindow = global.window;
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    (global as any).window = originalWindow;
+    (Platform as any).OS = originalPlatform;
+  });
+
+  it("returns false when web rendering has no window", () => {
+    (Platform as any).OS = "web";
+    delete (global as any).window;
+
+    expect(isRunningInIframe()).toBe(false);
+  });
+
+  it("returns true for an iframe window", () => {
+    (Platform as any).OS = "web";
+    (global as any).window = { self: {}, top: {} };
+
+    expect(isRunningInIframe()).toBe(true);
+  });
+});

--- a/dapps/pos-app/__tests__/utils/pos-bridge-ui.test.ts
+++ b/dapps/pos-app/__tests__/utils/pos-bridge-ui.test.ts
@@ -1,4 +1,5 @@
 import {
+  getMerchantIdForSession,
   getConnectionSetupRemaining,
   isTerminalConfigured,
   shouldRouteInvalidApiKeyToSettings,
@@ -6,6 +7,15 @@ import {
 } from "@/utils/pos-bridge-ui";
 
 describe("POS bridge UI state", () => {
+  it("uses the runtime bridge merchant only for iframe sessions", () => {
+    expect(
+      getMerchantIdForSession(true, "merchant-standalone", "merchant-bridge"),
+    ).toBe("merchant-bridge");
+    expect(
+      getMerchantIdForSession(false, "merchant-standalone", "merchant-bridge"),
+    ).toBe("merchant-standalone");
+  });
+
   it("allows home payment setup with a merchant ID and bridge, but not without either credential path", () => {
     expect(isTerminalConfigured("merchant-1", false, true)).toBe(true);
     expect(isTerminalConfigured("merchant-1", true, false)).toBe(true);

--- a/dapps/pos-app/app.json
+++ b/dapps/pos-app/app.json
@@ -35,7 +35,7 @@
         "android.permission.BLUETOOTH_ADVERTISE",
         "android.permission.USB_PERMISSION"
       ],
-      "versionCode": 4
+      "versionCode": 5
     },
     "web": {
       "output": "static",

--- a/dapps/pos-app/app/index.tsx
+++ b/dapps/pos-app/app/index.tsx
@@ -6,7 +6,10 @@ import { useTheme } from "@/hooks/use-theme-color";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import { usePosBridgeStore } from "@/store/usePosBridgeStore";
 import { isRunningInIframe } from "@/utils/is-running-in-iframe";
-import { isTerminalConfigured } from "@/utils/pos-bridge-ui";
+import {
+  getMerchantIdForSession,
+  isTerminalConfigured,
+} from "@/utils/pos-bridge-ui";
 import { showErrorToast } from "@/utils/toast";
 import { useAssets } from "expo-asset";
 import { Image } from "expo-image";
@@ -50,7 +53,7 @@ export default function HomeScreen() {
   const handleStartPayment = () => {
     if (
       !isTerminalConfigured(
-        isIframeSession ? bridgeMerchantId : merchantId,
+        getMerchantIdForSession(isIframeSession, merchantId, bridgeMerchantId),
         isIframeSession ? false : isCustomerApiKeySet,
         isIframeSession && isBridgeConfigured,
       )

--- a/dapps/pos-app/app/index.tsx
+++ b/dapps/pos-app/app/index.tsx
@@ -5,6 +5,7 @@ import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useTheme } from "@/hooks/use-theme-color";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import { usePosBridgeStore } from "@/store/usePosBridgeStore";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import { isTerminalConfigured } from "@/utils/pos-bridge-ui";
 import { showErrorToast } from "@/utils/toast";
 import { useAssets } from "expo-asset";
@@ -44,13 +45,14 @@ export default function HomeScreen() {
   );
   const isBridgeConfigured = usePosBridgeStore((state) => state.isConfigured);
   const bridgeMerchantId = usePosBridgeStore((state) => state.merchantId);
+  const isIframeSession = isRunningInIframe();
 
   const handleStartPayment = () => {
     if (
       !isTerminalConfigured(
-        bridgeMerchantId ?? merchantId,
-        isCustomerApiKeySet,
-        isBridgeConfigured,
+        isIframeSession ? bridgeMerchantId : merchantId,
+        isIframeSession ? false : isCustomerApiKeySet,
+        isIframeSession && isBridgeConfigured,
       )
     ) {
       router.push("/settings");

--- a/dapps/pos-app/app/payment-failure.tsx
+++ b/dapps/pos-app/app/payment-failure.tsx
@@ -11,6 +11,7 @@ import { useIsTablet } from "@/hooks/use-is-tablet";
 import { useTheme } from "@/hooks/use-theme-color";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import { usePosBridgeStore } from "@/store/usePosBridgeStore";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import {
   getPaymentErrorMessage,
   INVALID_API_KEY,
@@ -35,6 +36,7 @@ export default function PaymentFailureScreen() {
   const params: Partial<ScreenParams> = useLocalSearchParams<ScreenParams>();
   const currencyCode = useSettingsStore((state) => state.currency);
   const isBridgeConfigured = usePosBridgeStore((state) => state.isConfigured);
+  const isIframeBridgeConfigured = isRunningInIframe() && isBridgeConfigured;
   const [assets] = useAssets([
     require("@/assets/images/warning-circle-fill.png"),
   ]);
@@ -48,7 +50,7 @@ export default function PaymentFailureScreen() {
   // belong to the dashboard, so retrying starts a new payment instead.
   const shouldRouteToSettings = shouldRouteInvalidApiKeyToSettings(
     params.errorCode === INVALID_API_KEY,
-    isBridgeConfigured,
+    isIframeBridgeConfigured,
   );
 
   const handlePrimaryPress = () => {

--- a/dapps/pos-app/app/scan.tsx
+++ b/dapps/pos-app/app/scan.tsx
@@ -11,6 +11,7 @@ import { useTheme } from "@/hooks/use-theme-color";
 import { usePaymentStatus } from "@/services/hooks";
 import { cancelPayment, startPayment } from "@/services/payment";
 import { useLogsStore } from "@/store/useLogsStore";
+import { usePosBridgeStore } from "@/store/usePosBridgeStore";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import {
   amountToCents,
@@ -20,7 +21,9 @@ import {
 import { formatCountdown, formatCountdownSpoken } from "@/utils/misc";
 import { resetNavigation } from "@/utils/navigation";
 import { isNfcHceEnabled } from "@/utils/feature-flags";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import { AMOUNT_TOO_LOW, parseMinAmountCents } from "@/utils/payment-errors";
+import { getMerchantIdForSession } from "@/utils/pos-bridge-ui";
 import { showErrorToast, showSuccessToast } from "@/utils/toast";
 import { useAssets } from "expo-asset";
 import * as Clipboard from "expo-clipboard";
@@ -60,7 +63,13 @@ export default function ScanScreen() {
   const navigation = useNavigation();
 
   const deviceId = useSettingsStore((state) => state.deviceId);
-  const merchantId = useSettingsStore((state) => state.merchantId);
+  const storedMerchantId = useSettingsStore((state) => state.merchantId);
+  const bridgeMerchantId = usePosBridgeStore((state) => state.merchantId);
+  const merchantId = getMerchantIdForSession(
+    isRunningInIframe(),
+    storedMerchantId,
+    bridgeMerchantId,
+  );
   const currencyCode = useSettingsStore((state) => state.currency);
   const nfcEnabled = useSettingsStore((state) => state.nfcEnabled);
   const currency = getCurrency(currencyCode);

--- a/dapps/pos-app/app/settings.tsx
+++ b/dapps/pos-app/app/settings.tsx
@@ -16,6 +16,7 @@ import { useTheme } from "@/hooks/use-theme-color";
 import { useLogsStore } from "@/store/useLogsStore";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import { usePosBridgeStore } from "@/store/usePosBridgeStore";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import { ThemeMode } from "@/utils/types";
 import {
   getConnectionSetupRemaining,
@@ -87,6 +88,8 @@ export default function SettingsScreen() {
   const theme = useTheme();
   const isBridgeConfigured = usePosBridgeStore((state) => state.isConfigured);
   const bridgeMerchantId = usePosBridgeStore((state) => state.merchantId);
+  const isIframeSession = isRunningInIframe();
+  const isIframeBridgeConfigured = isIframeSession && isBridgeConfigured;
 
   const [activeSheet, setActiveSheet] = useState<ActiveSheet>(null);
 
@@ -180,16 +183,20 @@ export default function SettingsScreen() {
   const showBiometricToggle = shouldShowBiometricOption && !!biometricStatus;
 
   const hasMerchantId = !!storedMerchantId?.trim();
-  const setupRemaining = getConnectionSetupRemaining(
-    hasMerchantId,
-    hasStoredCustomerApiKey,
-    isBridgeConfigured,
-  );
-  const showConnectionSection = shouldShowConnectionSection(
-    isBridgeConfigured,
-    !!bridgeMerchantId,
-    showNfcToggle || showBiometricToggle,
-  );
+  const setupRemaining = isIframeSession
+    ? 0
+    : getConnectionSetupRemaining(
+        hasMerchantId,
+        hasStoredCustomerApiKey,
+        isIframeBridgeConfigured,
+      );
+  const showConnectionSection =
+    isIframeSession ||
+    shouldShowConnectionSection(
+      isIframeBridgeConfigured,
+      !!bridgeMerchantId,
+      showNfcToggle || showBiometricToggle,
+    );
 
   const handleTestPrinterPress = async () => {
     try {
@@ -274,7 +281,16 @@ export default function SettingsScreen() {
 
         {showConnectionSection && (
           <SettingsSection title="Connection">
-            {isBridgeConfigured ? (
+            {isIframeSession && !isIframeBridgeConfigured ? (
+              <SettingsItem
+                testID="settings-dashboard-bridge"
+                title="Dashboard bridge"
+                value="Waiting for dashboard"
+                onPress={() => undefined}
+                showCaret={false}
+                disabled
+              />
+            ) : isIframeBridgeConfigured ? (
               <SettingsItem
                 testID="settings-merchant-id"
                 title="Merchant ID"

--- a/dapps/pos-app/hooks/use-pos-bridge.ts
+++ b/dapps/pos-app/hooks/use-pos-bridge.ts
@@ -17,10 +17,6 @@ import { Platform } from "react-native";
 export function usePosBridge() {
   const hasInitialized = useRef(false);
   const hasHydrated = useSettingsStore((state) => state._hasHydrated);
-  const setMerchantId = useSettingsStore((state) => state.setMerchantId);
-  const clearCustomerApiKey = useSettingsStore(
-    (state) => state.clearCustomerApiKey,
-  );
 
   useEffect(() => {
     if (Platform.OS !== "web" || !hasHydrated || hasInitialized.current) {
@@ -31,19 +27,13 @@ export function usePosBridge() {
     let isMounted = true;
     const handleMessage = (event: MessageEvent) => {
       if (isPosBridgeConfigMessage(event.data)) {
-        if (
-          event.source === window.parent &&
+        if (window.parent !== window && event.source === window.parent) {
+          // Keep bridge credentials runtime-only.
           configureBridge(
             event.source as Window,
             event.origin,
             event.data.merchantId.trim(),
-          )
-        ) {
-          setMerchantId(event.data.merchantId.trim());
-          // A bridge uses the dashboard's key outside this frame. Remove any
-          // local key left by a direct or older embedded POS session. This is
-          // best effort: bridge state does not depend on local secure storage.
-          void clearCustomerApiKey().catch(() => undefined);
+          );
         }
         return;
       }
@@ -54,13 +44,7 @@ export function usePosBridge() {
 
     window.addEventListener("message", handleMessage);
 
-    const initialize = async () => {
-      if (window.parent !== window) {
-        // Do not retain an old local key while an embedded POS is waiting for
-        // bridge configuration. No URL or legacy credential fallback exists.
-        await clearCustomerApiKey().catch(() => undefined);
-      }
-
+    const initialize = () => {
       if (isMounted) {
         window.parent.postMessage(
           { type: "pos-ready", protocolVersion: PROTOCOL_VERSION },
@@ -69,11 +53,11 @@ export function usePosBridge() {
       }
     };
 
-    void initialize();
+    initialize();
     return () => {
       isMounted = false;
       window.removeEventListener("message", handleMessage);
       resetBridge("POS bridge listener was unmounted");
     };
-  }, [clearCustomerApiKey, hasHydrated, setMerchantId]);
+  }, [hasHydrated]);
 }

--- a/dapps/pos-app/services/payment.web.ts
+++ b/dapps/pos-app/services/payment.web.ts
@@ -1,5 +1,6 @@
 import { useSettingsStore } from "@/store/useSettingsStore";
-import { isBridgeConfigured, requestBridge } from "@/services/pos-bridge";
+import { requestBridge } from "@/services/pos-bridge";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import {
   ApiError,
   PaymentStatusResponse,
@@ -38,7 +39,8 @@ async function getMerchantCredentials(): Promise<{
 export async function startPayment(
   request: StartPaymentRequest,
 ): Promise<StartPaymentResponse> {
-  if (isBridgeConfigured()) {
+  // Iframes never use local credentials.
+  if (isRunningInIframe()) {
     return requestBridge<StartPaymentResponse>({
       operation: "start-payment",
       payload: request,
@@ -83,7 +85,7 @@ export async function getPaymentStatus(
     throw new Error("paymentId is required");
   }
 
-  if (isBridgeConfigured()) {
+  if (isRunningInIframe()) {
     return requestBridge<PaymentStatusResponse>({
       operation: "get-payment-status",
       payload: { paymentId },
@@ -127,7 +129,7 @@ export async function cancelPayment(paymentId: string): Promise<void> {
     throw new Error("paymentId is required");
   }
 
-  if (isBridgeConfigured()) {
+  if (isRunningInIframe()) {
     await requestBridge<void>({
       operation: "cancel-payment",
       payload: { paymentId },

--- a/dapps/pos-app/services/transactions.web.ts
+++ b/dapps/pos-app/services/transactions.web.ts
@@ -1,9 +1,9 @@
 import { useSettingsStore } from "@/store/useSettingsStore";
 import {
   GetTransactionsBridgeOptions,
-  isBridgeConfigured,
   requestBridge,
 } from "@/services/pos-bridge";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import { TransactionsResponse } from "@/utils/types";
 
 export type GetTransactionsOptions = GetTransactionsBridgeOptions;
@@ -16,7 +16,7 @@ export type GetTransactionsOptions = GetTransactionsBridgeOptions;
 export async function getTransactions(
   options: GetTransactionsOptions = {},
 ): Promise<TransactionsResponse> {
-  if (isBridgeConfigured()) {
+  if (isRunningInIframe()) {
     return requestBridge<TransactionsResponse>({
       operation: "get-transactions",
       payload: options,

--- a/dapps/pos-app/store/useLogsStore.ts
+++ b/dapps/pos-app/store/useLogsStore.ts
@@ -1,4 +1,5 @@
 import { storage } from "@/utils/storage";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import { DateRangeFilterType, LogLevelFilterType } from "@/utils/types";
 import { v4 as uuidv4 } from "uuid";
 import { create } from "zustand";
@@ -39,6 +40,21 @@ interface LogsStore {
 
 // -- Constants ----------------------------------------- //
 const MAX_LOGS_COUNT = 100;
+
+const logsStorage = {
+  getItem: <T = any>(key: string) => {
+    if (isRunningInIframe()) return null;
+    return storage.getItem<T>(key);
+  },
+  setItem: <T = any>(key: string, value: T) => {
+    if (isRunningInIframe()) return;
+    return storage.setItem(key, value);
+  },
+  removeItem: (key: string) => {
+    if (isRunningInIframe()) return;
+    return storage.removeItem(key);
+  },
+};
 
 // -- Store --------------------------------------------- //
 export const useLogsStore = create<LogsStore>()(
@@ -95,7 +111,7 @@ export const useLogsStore = create<LogsStore>()(
     {
       name: "logs",
       version: 1,
-      storage,
+      storage: logsStorage,
       onRehydrateStorage: () => (state, error) => {
         if (error) {
           console.error("Logs hydration failed:", error);

--- a/dapps/pos-app/store/useSettingsStore.ts
+++ b/dapps/pos-app/store/useSettingsStore.ts
@@ -8,7 +8,7 @@ import {
   SECURE_STORAGE_KEYS,
   secureStorage,
 } from "@/utils/secure-storage";
-import { isEmbedded } from "@/utils/is-embedded";
+import { isRunningInIframe } from "@/utils/is-running-in-iframe";
 import { storage } from "@/utils/storage";
 import {
   DateRangeFilterType,
@@ -368,20 +368,24 @@ export const useSettingsStore = create<SettingsStore>()(
             delete (state as any).__migrationData;
           }
 
-          // Run customer API key migration before applying defaults
-          // This ensures existing users keep their API key during the rename
-          const migrated = await migrateCustomerApiKey();
-          if (migrated) {
-            // Migration was performed, sync the flag
-            state.isCustomerApiKeySet = true;
-            useLogsStore
-              .getState()
-              .addLog(
-                "info",
-                "Customer API key migrated from legacy storage key",
-                "Settings",
-                "onRehydrateStorage",
-              );
+          // Skip credential migrations in iframes.
+          if (!isRunningInIframe()) {
+            // Run customer API key migration before applying defaults.
+            // This ensures existing standalone users keep their API key during
+            // the rename.
+            const migrated = await migrateCustomerApiKey();
+            if (migrated) {
+              // Migration was performed, sync the flag
+              state.isCustomerApiKeySet = true;
+              useLogsStore
+                .getState()
+                .addLog(
+                  "info",
+                  "Customer API key migrated from legacy storage key",
+                  "Settings",
+                  "onRehydrateStorage",
+                );
+            }
           }
 
           // Sync isPinHashSet from secure storage
@@ -393,7 +397,7 @@ export const useSettingsStore = create<SettingsStore>()(
           // Initialize merchant defaults from env on first run only, so we
           // don't re-seed defaults after the user clears/changes credentials.
           // Skip when embedded in an iframe — parent provides credentials via postMessage.
-          if (!isEmbedded() && !state.hasInitializedDefaults) {
+          if (!isRunningInIframe() && !state.hasInitializedDefaults) {
             const defaultMerchantId = MerchantConfig.getDefaultMerchantId();
             const defaultApiKey = MerchantConfig.getDefaultCustomerApiKey();
 

--- a/dapps/pos-app/utils/is-running-in-iframe.ts
+++ b/dapps/pos-app/utils/is-running-in-iframe.ts
@@ -5,7 +5,7 @@ import { Platform } from "react-native";
  * Always returns false on native platforms.
  */
 export function isRunningInIframe(): boolean {
-  if (Platform.OS !== "web") return false;
+  if (Platform.OS !== "web" || typeof window === "undefined") return false;
   try {
     return window.self !== window.top;
   } catch {

--- a/dapps/pos-app/utils/is-running-in-iframe.ts
+++ b/dapps/pos-app/utils/is-running-in-iframe.ts
@@ -1,15 +1,15 @@
 import { Platform } from "react-native";
 
 /**
- * Returns true when the web app is running inside an iframe.
+ * Returns true when the web POS is running inside an iframe.
  * Always returns false on native platforms.
  */
-export function isEmbedded(): boolean {
+export function isRunningInIframe(): boolean {
   if (Platform.OS !== "web") return false;
   try {
     return window.self !== window.top;
   } catch {
-    // Cross-origin iframes throw on window.top access — that means we're embedded
+    // Cross-origin access means the POS is running in an iframe.
     return true;
   }
 }

--- a/dapps/pos-app/utils/pos-bridge-ui.ts
+++ b/dapps/pos-app/utils/pos-bridge-ui.ts
@@ -1,3 +1,11 @@
+export function getMerchantIdForSession(
+  isIframeSession: boolean,
+  merchantId: string | null,
+  bridgeMerchantId: string | null,
+): string | null {
+  return isIframeSession ? bridgeMerchantId : merchantId;
+}
+
 export function isTerminalConfigured(
   merchantId: string | null,
   hasLocalApiKey: boolean,


### PR DESCRIPTION
## Summary
- keep iframe bridge credentials and merchant state runtime-only
- prevent iframe API and log activity from reading or writing standalone storage
- enforce iframe-only bridge configuration and clarify the iframe detector

## Validation
- npm test -- --runInBand __tests__/store/useLogsStore.test.ts __tests__/hooks/use-pos-bridge.test.ts __tests__/services/web-bridge-services.test.ts __tests__/utils/pos-bridge-ui.test.ts
- npm run lint